### PR TITLE
[DOCS] Add apiary link to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ php artisan passport:install
 php artisan serve
 ```
 
+## Api specifications
+Available on [apiary.io](http://docs.technicsolder.apiary.io/#)
+
 ## Change log
 
 Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recently.


### PR DESCRIPTION
Adds the apiary link for the api docs to the readme, so it's easy to find, for people to read up on. 

Or mainly because i keep losing the link.

**What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)**
Docs update


**What is the current behavior? (You can also link to an open issue here)**
The link to the api docs are missing


**What is the new behavior (if this is a feature change)?**
The link is there


**Does this PR introduce a breaking change?**
No. 


**Please check if the PR fulfills these requirements**
- [ ] The commit message follows our guidelines: https://github.com/indemnity3/solder/blob/develop/CONTRIBUTING.md#commit-message-format
i'm not pulling to amend the commit title for just this. 
