### PR TITLE
feat(core): leverage route model binding in controllers

### DIFF
--- a/app/Build.php
+++ b/app/Build.php
@@ -45,6 +45,16 @@ class Build extends Model
     }
 
     /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName()
+    {
+        return 'version';
+    }
+
+    /**
      * Filter query results to public builds, private builds
      * that have been authorized with the provided client token
      * and all private builds with a valid provided api key.

--- a/app/Build.php
+++ b/app/Build.php
@@ -25,6 +25,25 @@ class Build extends Model
     protected $guarded = [];
 
     /**
+     * Retrieve the first build matching the given modpack slug and build version.
+     *
+     * @param $modpack
+     * @param $version
+     * @return self
+     */
+    public static function findByModpackSlugAndBuildVersion($modpack, $version)
+    {
+        return self::where('version', $version)
+            ->whereExists(function ($query) use ($modpack) {
+                $query->select(DB::raw(1))
+                    ->from('modpacks')
+                    ->where('slug', $modpack)
+                    ->whereRaw('builds.modpack_id = modpacks.id');
+            })
+            ->first();
+    }
+
+    /**
      * A Build contains many Releases of various Packages.
      *
      * @return \Illuminate\Database\Eloquent\Relations\BelongsToMany

--- a/app/Collaborator.php
+++ b/app/Collaborator.php
@@ -21,4 +21,9 @@ class Collaborator extends Model
     {
         return $this->belongsTo(User::class);
     }
+
+    public function modpack()
+    {
+        return $this->belongsTo(Modpack::class);
+    }
 }

--- a/app/Http/Controllers/Admin/ClientsController.php
+++ b/app/Http/Controllers/Admin/ClientsController.php
@@ -52,14 +52,11 @@ class ClientsController extends Controller
     /**
      * Delete the client.
      *
-     * @param $clientId
-     *
+     * @param Client $client
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function destroy($clientId)
+    public function destroy(Client $client)
     {
-        $client = Client::find($clientId);
-
         $this->authorize('delete', $client);
 
         $client->delete();

--- a/app/Http/Controllers/Admin/KeysController.php
+++ b/app/Http/Controllers/Admin/KeysController.php
@@ -50,13 +50,12 @@ class KeysController extends Controller
     /**
      * Delete a key.
      *
-     * @param $keyId
-     *
+     * @param Key $key
      * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
-    public function destroy($keyId)
+    public function destroy(Key $key)
     {
-        Key::findOrFail($keyId)->delete();
+        $key->delete();
 
         return redirect('/settings/keys');
     }

--- a/app/Http/Controllers/Admin/UsersController.php
+++ b/app/Http/Controllers/Admin/UsersController.php
@@ -56,15 +56,14 @@ class UsersController extends Controller
     /**
      * Update a users details.
      *
-     * @param $userId
-     *
+     * @param User $user
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function update($userId)
+    public function update(User $user)
     {
-        $user = request()->validate([
-            'username' => ['required', Rule::unique('users')->ignore($userId)],
-            'email' => ['required', 'email', Rule::unique('users')->ignore($userId)],
+        $data = request()->validate([
+            'username' => ['required', Rule::unique('users')->ignore($user->id)],
+            'email' => ['required', 'email', Rule::unique('users')->ignore($user->id)],
         ]);
 
         if (request('password') != '') {
@@ -72,12 +71,12 @@ class UsersController extends Controller
                 'password' => ['min:6'],
             ]);
 
-            $user['password'] = bcrypt(request('password'));
+            $data['password'] = bcrypt(request('password'));
         }
 
-        $user['is_admin'] = request('is_admin') == 'on';
+        $data['is_admin'] = request('is_admin') == 'on';
 
-        User::find($userId)->update($user);
+        $user->update($data);
 
         return redirect('/settings/users/');
     }
@@ -85,14 +84,11 @@ class UsersController extends Controller
     /**
      * Delete a user.
      *
-     * @param $userId
-     *
+     * @param User $user
      * @return \Illuminate\Contracts\Routing\ResponseFactory|\Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|\Symfony\Component\HttpFoundation\Response
      */
-    public function destroy($userId)
+    public function destroy(User $user)
     {
-        $user = User::findOrFail($userId);
-
         if (Auth::user()->is($user)) {
             return response('You may not remove your own user.', 403);
         }

--- a/app/Http/Controllers/Api/PackagesController.php
+++ b/app/Http/Controllers/Api/PackagesController.php
@@ -30,12 +30,13 @@ class PackagesController extends Controller
     /**
      * Return details about a specific package.
      *
-     * @param Package $package
-     *
+     * @param $packageId
      * @return \Illuminate\Http\JsonResponse
      */
-    public function show(Package $package)
+    public function show($packageId)
     {
+        $package = Package::findOrFail($packageId);
+
         return fractal($package, new PackageTransformer())->respond();
     }
 }

--- a/app/Http/Controllers/BundlesController.php
+++ b/app/Http/Controllers/BundlesController.php
@@ -27,7 +27,7 @@ class BundlesController extends Controller
             'release_id' => request()->release_id,
         ]);
 
-        return redirect('/modpacks/'.$bundle->build->modpack->slug.'/'.$bundle->build->version);
+        return redirect()->route('builds.show', [$bundle->build->modpack, $bundle->build]);
     }
 
     /**

--- a/app/Http/Controllers/CollaboratorsController.php
+++ b/app/Http/Controllers/CollaboratorsController.php
@@ -21,6 +21,6 @@ class CollaboratorsController extends Controller
 
         $collaborator->delete();
 
-        return redirect('modpacks/'.$collaborator->modpack->slug);
+        return redirect()->route('modpacks.show', $collaborator->modpack);
     }
 }

--- a/app/Http/Controllers/CollaboratorsController.php
+++ b/app/Http/Controllers/CollaboratorsController.php
@@ -11,20 +11,16 @@
 
 namespace App\Http\Controllers;
 
-use App\Modpack;
 use App\Collaborator;
 
 class CollaboratorsController extends Controller
 {
-    public function destroy($collaboratorId)
+    public function destroy(Collaborator $collaborator)
     {
-        $collaborator = Collaborator::find($collaboratorId);
-        $modpack = Modpack::find($collaborator->modpack_id);
-
-        $this->authorize('update', $modpack);
+        $this->authorize('update', $collaborator->modpack);
 
         $collaborator->delete();
 
-        return redirect('modpacks/'.$modpack->slug);
+        return redirect('modpacks/'.$collaborator->modpack->slug);
     }
 }

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -21,19 +21,12 @@ class ModpackBuildsController extends Controller
     /**
      * Show the modpack build.
      *
-     * @param $modpackSlug
+     * @param Modpack $modpack
      * @param $buildVersion
-     *
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function show($modpackSlug, $buildVersion)
+    public function show(Modpack $modpack, $buildVersion)
     {
-        $modpack = Modpack::where('slug', $modpackSlug)
-            ->with(['builds' => function ($query) {
-                $query->orderBy('version', 'desc');
-            }])
-            ->firstOrFail();
-
         $build = Build::with(['releases.package', 'releases' => function ($query) {
             $query->join('packages', 'releases.package_id', '=', 'packages.id')
                 ->orderBy('packages.name');
@@ -52,14 +45,11 @@ class ModpackBuildsController extends Controller
     /**
      * Store the passed data as a build.
      *
-     * @param $modpackSlug
-     *
+     * @param Modpack $modpack
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function store($modpackSlug)
+    public function store(Modpack $modpack)
     {
-        $modpack = Modpack::where('slug', $modpackSlug)->first();
-
         $this->authorize('update', $modpack);
 
         request()->validate([
@@ -69,7 +59,7 @@ class ModpackBuildsController extends Controller
             'required_memory' => ['nullable', 'numeric'],
         ]);
 
-        $build = $modpack->builds()->create([
+        $modpack->builds()->create([
             'version' => request('version'),
             'minecraft_version' => request('minecraft_version'),
             'status' => request('status'),
@@ -84,14 +74,13 @@ class ModpackBuildsController extends Controller
     /**
      * Update a build.
      *
-     * @param $modpackSlug
+     * @param Modpack $modpack
      * @param $buildVersion
-     *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
+     * @internal param $modpackSlug
      */
-    public function update($modpackSlug, $buildVersion)
+    public function update(Modpack $modpack, $buildVersion)
     {
-        $modpack = Modpack::where('slug', $modpackSlug)->firstOrFail();
         $build = $modpack->builds()->where('version', $buildVersion)->firstOrFail();
 
         $this->authorize('update', $modpack);

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -118,14 +118,12 @@ class ModpackBuildsController extends Controller
     /**
      * Remove build from application.
      *
-     * @param $modpackSlug
+     * @param Modpack $modpack
      * @param $buildVersion
-     *
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function destroy($modpackSlug, $buildVersion)
+    public function destroy(Modpack $modpack, $buildVersion)
     {
-        $modpack = Modpack::where('slug', $modpackSlug)->firstOrFail();
         $this->authorize('update', $modpack);
 
         $build = Build::where('version', $buildVersion)

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -112,7 +112,7 @@ class ModpackBuildsController extends Controller
             'forge_version',
         ]));
 
-        return redirect("/modpacks/$modpackSlug/{$build->version}");
+        return redirect()->route('builds.show', [$modpack, $build]);
     }
 
     /**

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -78,7 +78,7 @@ class ModpackBuildsController extends Controller
             'forge_version' => request('forge_version'),
         ]);
 
-        return redirect("/modpacks/$modpackSlug");
+        return redirect()->route('modpacks.show', $modpack);
     }
 
     /**
@@ -132,6 +132,6 @@ class ModpackBuildsController extends Controller
 
         $build->delete();
 
-        return redirect("/modpacks/$modpackSlug");
+        return redirect()->route('modpacks.show', $modpack);
     }
 }

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -22,18 +22,15 @@ class ModpackBuildsController extends Controller
      * Show the modpack build.
      *
      * @param Modpack $modpack
-     * @param $buildVersion
+     * @param Build $build
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function show(Modpack $modpack, $buildVersion)
+    public function show(Modpack $modpack, Build $build)
     {
-        $build = Build::with(['releases.package', 'releases' => function ($query) {
+        $build->load(['releases.package', 'releases' => function ($query) {
             $query->join('packages', 'releases.package_id', '=', 'packages.id')
                 ->orderBy('packages.name');
-        }])
-            ->where('modpack_id', $modpack->id)
-            ->where('version', $buildVersion)
-            ->firstOrFail();
+        }]);
 
         return view('builds.show', [
             'modpack' => $modpack,
@@ -75,14 +72,11 @@ class ModpackBuildsController extends Controller
      * Update a build.
      *
      * @param Modpack $modpack
-     * @param $buildVersion
+     * @param Build $build
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
-     * @internal param $modpackSlug
      */
-    public function update(Modpack $modpack, $buildVersion)
+    public function update(Modpack $modpack, Build $build)
     {
-        $build = $modpack->builds()->where('version', $buildVersion)->firstOrFail();
-
         $this->authorize('update', $modpack);
 
         request()->validate([
@@ -108,16 +102,12 @@ class ModpackBuildsController extends Controller
      * Remove build from application.
      *
      * @param Modpack $modpack
-     * @param $buildVersion
+     * @param Build $build
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function destroy(Modpack $modpack, $buildVersion)
+    public function destroy(Modpack $modpack, Build $build)
     {
         $this->authorize('update', $modpack);
-
-        $build = Build::where('version', $buildVersion)
-            ->where('modpack_id', $modpack->id)
-            ->firstOrFail();
 
         $build->delete();
 

--- a/app/Http/Controllers/ModpackCollaboratorsController.php
+++ b/app/Http/Controllers/ModpackCollaboratorsController.php
@@ -15,10 +15,8 @@ use App\Modpack;
 
 class ModpackCollaboratorsController extends Controller
 {
-    public function store($modpackSlug)
+    public function store(Modpack $modpack)
     {
-        $modpack = Modpack::where('slug', $modpackSlug)->first();
-
         $this->authorize('update', $modpack);
 
         request()->validate([

--- a/app/Http/Controllers/ModpackCollaboratorsController.php
+++ b/app/Http/Controllers/ModpackCollaboratorsController.php
@@ -25,6 +25,6 @@ class ModpackCollaboratorsController extends Controller
 
         $modpack->addCollaborator(request('user_id'));
 
-        return redirect('modpacks/'.$modpackSlug);
+        return redirect()->route('modpacks.show', $modpack);
     }
 }

--- a/app/Http/Controllers/ModpacksController.php
+++ b/app/Http/Controllers/ModpacksController.php
@@ -21,17 +21,14 @@ class ModpacksController extends Controller
     /**
      * Show a modpack.
      *
-     * @param $slug
-     *
+     * @param Modpack $modpack
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function show($slug)
+    public function show(Modpack $modpack)
     {
-        $modpack = Modpack::where('slug', $slug)
-            ->with(['builds' => function ($query) {
-                $query->orderBy('created_at', 'desc');
-            }])
-            ->firstOrFail();
+        $modpack->load(['builds' => function ($query) {
+            $query->orderBy('created_at', 'desc');
+        }]);
 
         return view('modpacks.show', [
             'modpack' => $modpack,
@@ -70,14 +67,11 @@ class ModpacksController extends Controller
     /**
      * Update a modpack with the request data.
      *
-     * @param $slug
-     *
+     * @param Modpack $modpack
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function update($slug)
+    public function update(Modpack $modpack)
     {
-        $modpack = Modpack::where('slug', $slug)->first();
-
         $this->authorize('update', $modpack);
 
         request()->validate([
@@ -110,14 +104,11 @@ class ModpacksController extends Controller
     /**
      * Delete a modpack from the database.
      *
-     * @param $slug
-     *
+     * @param Modpack $modpack
      * @return \Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector
      */
-    public function destroy($slug)
+    public function destroy(Modpack $modpack)
     {
-        $modpack = Modpack::where('slug', $slug)->firstOrFail();
-
         $this->authorize('delete', $modpack);
 
         $modpack->delete();

--- a/app/Http/Controllers/ModpacksController.php
+++ b/app/Http/Controllers/ModpacksController.php
@@ -61,7 +61,7 @@ class ModpacksController extends Controller
 
         $modpack->addCollaborator(auth()->user()->id);
 
-        return redirect('/modpacks/'.request('slug'));
+        return redirect()->route('modpacks.show', $modpack);
     }
 
     /**
@@ -98,7 +98,7 @@ class ModpacksController extends Controller
             ]);
         }
 
-        return redirect('/modpacks/'.$modpack->slug);
+        return redirect()->route('modpacks.show', $modpack);
     }
 
     /**

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -31,17 +31,14 @@ class PackagesController extends Controller
     /**
      * Show details of a specific package and its releases.
      *
-     * @param $packageSlug
-     *
+     * @param Package $package
      * @return \Illuminate\Contracts\View\Factory|\Illuminate\View\View
      */
-    public function show($packageSlug)
+    public function show(Package $package)
     {
-        $package = Package::where('slug', $packageSlug)
-            ->with(['releases' => function ($query) {
-                $query->orderBy('version', 'desc');
-            }])
-            ->first();
+        $package->load(['releases' => function ($query) {
+            $query->orderBy('version', 'desc');
+        }]);
 
         return view('packages.show', [
             'package' => $package,
@@ -77,10 +74,8 @@ class PackagesController extends Controller
         return redirect('library/'.$package->slug);
     }
 
-    public function update($packageSlug)
+    public function update(Package $package)
     {
-        $package = Package::where('slug', $packageSlug)->firstOrFail();
-
         $this->authorize('update', $package);
 
         request()->validate([
@@ -100,10 +95,8 @@ class PackagesController extends Controller
         return redirect('library/'.$package->slug);
     }
 
-    public function destroy($packageSlug)
+    public function destroy(Package $package)
     {
-        $package = Package::where('slug', $packageSlug)->firstOrFail();
-
         $this->authorize('delete', $package);
 
         $package->delete();

--- a/app/Http/Controllers/ReleasesController.php
+++ b/app/Http/Controllers/ReleasesController.php
@@ -18,14 +18,11 @@ class ReleasesController extends Controller
     /**
      * Delete a release.
      *
-     * @param $releaseId
-     *
+     * @param Release $release
      * @return \Illuminate\Contracts\Routing\ResponseFactory|\Symfony\Component\HttpFoundation\Response
      */
-    public function destroy($releaseId)
+    public function destroy(Release $release)
     {
-        $release = Release::findOrFail($releaseId);
-
         $this->authorize('delete', $release);
 
         $release->delete();

--- a/app/Modpack.php
+++ b/app/Modpack.php
@@ -67,6 +67,16 @@ class Modpack extends Model
     }
 
     /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
+
+    /**
      * Filter query results to public modpack, private modpacks
      * that have been authorized with the provided client token
      * and all private modpacks with a valid provided api key.

--- a/app/Package.php
+++ b/app/Package.php
@@ -43,4 +43,14 @@ class Package extends Model
     {
         return $this->hasMany(Release::class);
     }
+
+    /**
+     * Get the route key for the model.
+     *
+     * @return string
+     */
+    public function getRouteKeyName()
+    {
+        return 'slug';
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -32,9 +32,13 @@ class RouteServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
-
         parent::boot();
+
+        Route::bind('build', function ($version) {
+            $slug = request()->route('modpack');
+
+            return \App\Build::findByModpackSlugAndBuildVersion($slug, $version);
+        });
     }
 
     /**

--- a/resources/views/builds/partials/danger-zone.blade.php
+++ b/resources/views/builds/partials/danger-zone.blade.php
@@ -13,24 +13,27 @@
                 </div>
                 <div class="level-right">
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $build->modpack->slug }}/{{ $build->version }}">
+                        <form method="post" action="{{ route('builds.update', [$build->modpack, $build]) }}">
                             {{ csrf_field() }}
+                            {{ method_field('patch') }}
 
                             <input type="hidden" name="status" value="draft" />
                             <button class="button {{ $build->status == 'draft' ? 'is-static' : 'is-danger' }} is-outlined" type="submit">Draft</button>
                         </form>
                     </div>
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $build->modpack->slug }}/{{ $build->version }}">
+                        <form method="post" action="{{ route('builds.update', [$build->modpack, $build]) }}">
                             {{ csrf_field() }}
+                            {{ method_field('patch') }}
 
                             <input type="hidden" name="status" value="private" />
                             <button class="button {{ $build->status == 'private' ? 'is-static' : 'is-danger' }} is-outlined" type="submit">Private</button>
                         </form>
                     </div>
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $build->modpack->slug }}/{{ $build->version }}">
+                        <form method="post" action="{{ route('builds.update', [$build->modpack, $build]) }}">
                             {{ csrf_field() }}
+                            {{ method_field('patch') }}
 
                             <button class="button {{ $build->status == 'public' ? 'is-static' : 'is-danger' }} is-outlined" type="submit">Public</button>
                             <input type="hidden" name="status" value="public" />
@@ -49,8 +52,9 @@
                 </div>
                 <div class="level-right">
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $build->modpack->slug }}/{{ $build->version }}">
+                        <form method="post" action="{{ route('builds.update', [$build->modpack, $build]) }}">
                             {{ csrf_field() }}
+                            {{ method_field('patch') }}
 
                             <div class="field has-addons">
                                 <div class="control">
@@ -80,7 +84,7 @@
                 </div>
                 <div class="level-right">
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $build->modpack->slug }}/{{ $build->version }}">
+                        <form method="post" action="{{ route('builds.destroy', [$build->modpack, $build]) }}">
                             {{ csrf_field() }}
                             {{ method_field('delete') }}
                             <button class="button is-danger is-outlined" type="submit">Delete this build</button>

--- a/resources/views/builds/partials/update-build.blade.php
+++ b/resources/views/builds/partials/update-build.blade.php
@@ -1,8 +1,9 @@
 <div class="box">
     <h1>Build Settings</h1>
     <div class="box-body">
-        <form method="post" action="/modpacks/{{ $build->modpack->slug }}/{{ $build->version }}" enctype="multipart/form-data">
+        <form method="post" action="{{ route('builds.update', [$build->modpack, $build]) }}" enctype="multipart/form-data">
             {{ csrf_field() }}
+            {{ method_field('patch') }}
 
             <div class="field is-horizontal">
                 <div class="field-label is-normal">

--- a/resources/views/builds/show.blade.php
+++ b/resources/views/builds/show.blade.php
@@ -14,7 +14,7 @@
             <div class="level-left"></div>
             <div class="level-right">
                 <div class="level-item has-padding-right-3">
-                    <a href="/modpacks/{{ $build->modpack->slug }}" class="menu-label">
+                    <a href="{{ route('modpacks.show', $build->modpack) }}" class="menu-label">
                         <figure class="icon">
                             <i class="fa fa-fw fa-arrow-left"></i>
                         </figure>

--- a/resources/views/dashboard/partials/create-modpack.blade.php
+++ b/resources/views/dashboard/partials/create-modpack.blade.php
@@ -1,7 +1,7 @@
 <div class="box">
     <h1>Create Modpack</h1>
     <div class="box-body">
-        <form action="/modpacks" method="post" id="create-modpack" enctype="multipart/form-data">
+        <form action="{{ route('modpacks.store') }}" method="post" id="create-modpack" enctype="multipart/form-data">
         {{ csrf_field() }}
 
         <!-- Name -->

--- a/resources/views/dashboard/partials/recent-builds.blade.php
+++ b/resources/views/dashboard/partials/recent-builds.blade.php
@@ -13,7 +13,7 @@
         @foreach($builds as $build)
             <tr>
                 <td>
-                    <a href="/modpacks/{{ $build->modpack->slug }}/{{ $build->version }}">
+                    <a href="{{ route('builds.show', [$build->modpack, $build]) }}">
                         <strong>{{ $build->version }}</strong>
                     </a>
                 </td>

--- a/resources/views/dashboard/partials/recent-builds.blade.php
+++ b/resources/views/dashboard/partials/recent-builds.blade.php
@@ -18,7 +18,7 @@
                     </a>
                 </td>
                 <td>
-                    <a href="/modpacks/{{ $build->modpack->slug }}">
+                    <a href="{{ route('modpacks.show', $build->modpack) }}">
                         <strong>{{ $build->modpack->name }}</strong>
                     </a>
                 </td>

--- a/resources/views/modpacks/partials/create-build.blade.php
+++ b/resources/views/modpacks/partials/create-build.blade.php
@@ -1,7 +1,7 @@
 <div class="box">
     <h1>Add Build</h1>
     <div class="box-body">
-        <form method="post" action="/modpacks/{{ $modpack->slug }}/builds">
+        <form method="post" action="{{ route('builds.store', $modpack) }}">
             {{ csrf_field() }}
 
             <div class="field is-horizontal">

--- a/resources/views/modpacks/partials/danger-zone.blade.php
+++ b/resources/views/modpacks/partials/danger-zone.blade.php
@@ -14,7 +14,7 @@
                     </div>
                     <div class="level-right">
                         <div class="level-item">
-                            <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                            <form method="post" action="{{ route('modpacks.update', $modpack) }}">
                                 {{ csrf_field() }}
                                 {{ method_field('patch') }}
 
@@ -37,7 +37,7 @@
                     </div>
                     <div class="level-right">
                         <div class="level-item">
-                            <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                            <form method="post" action="{{ route('modpacks.update', $modpack) }}">
                                 {{ csrf_field() }}
                                 {{ method_field('patch') }}
 
@@ -59,7 +59,7 @@
                 </div>
                 <div class="level-right">
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                        <form method="post" action="{{ route('modpacks.update', $modpack) }}">
                             {{ csrf_field() }}
                             {{ method_field('patch') }}
 
@@ -91,7 +91,7 @@
                 </div>
                 <div class="level-right">
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                        <form method="post" action="{{ route('modpacks.destroy', $modpack) }}">
                             {{ csrf_field() }}
                             {{ method_field('delete') }}
                             <button class="button is-danger is-outlined" type="submit">Delete this modpack</button>

--- a/resources/views/modpacks/partials/list-builds.blade.php
+++ b/resources/views/modpacks/partials/list-builds.blade.php
@@ -32,7 +32,7 @@
                 <td>{{ $build->java_version }}</td>
                 <td>{{ $build->required_memory }}</td>
                 <td class="has-text-centered is-narrow">
-                    <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                    <form method="post" action="{{ route('modpacks.update', $build->modpack) }}">
                         {{ csrf_field() }}
                         {{ method_field('patch') }}
                         <input type="hidden" name="recommended_build_id" value="{{ $build->id }}" />
@@ -49,7 +49,7 @@
                     </form>
                 </td>
                 <td class="has-text-centered is-narrow">
-                    <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                    <form method="post" action="{{ route('modpacks.update', $build->modpack) }}">
                         {{ csrf_field() }}
                         {{ method_field('patch') }}
                         <input type="hidden" name="latest_build_id" value="{{ $build->id }}" />

--- a/resources/views/modpacks/partials/list-builds.blade.php
+++ b/resources/views/modpacks/partials/list-builds.blade.php
@@ -17,7 +17,7 @@
         @foreach($modpack->builds as $build)
             <tr>
                 <td>
-                    <a href="/modpacks/{{ $modpack->slug }}/{{ $build->version }}">
+                    <a href="{{ route('builds.show', [$modpack, $build]) }}">
                         <strong>{{ $build->version }}</strong>
                         @if($build->status == 'private')
                             <span class="tag">private</span>
@@ -66,7 +66,7 @@
                     </form>
                 </td>
                 <td class="has-text-right">
-                    <form method="post" action="/modpacks/{{ $modpack->slug }}/{{ $build->version }}">
+                    <form method="post" action="{{ route('builds.destroy', [$modpack, $build]) }}">
                         {{ csrf_field() }}
                         {{ method_field('delete') }}
                         <button class="button is-danger is-small is-outlined">Delete</button>

--- a/resources/views/modpacks/partials/update-modpack.blade.php
+++ b/resources/views/modpacks/partials/update-modpack.blade.php
@@ -1,7 +1,7 @@
 <div class="box">
     <h1>Modpack Settings</h1>
     <div class="box-body">
-        <form method="post" action="/modpacks/{{ $modpack->slug }}" enctype="multipart/form-data">
+        <form method="post" action="{{ route('modpacks.update', $modpack) }}" enctype="multipart/form-data">
             {{ csrf_field() }}
             {{ method_field('patch') }}
 

--- a/resources/views/partials/directory.blade.php
+++ b/resources/views/partials/directory.blade.php
@@ -18,7 +18,7 @@
     </div>
     <div class="directory-menu">
         @foreach($directory as $modpackItem)
-        <a class="directory-item {{ isset($modpack) && $modpack->id == $modpackItem->id ? 'is-active' : '' }}" href="/modpacks/{{ $modpackItem->slug }}">
+        <a class="directory-item {{ isset($modpack) && $modpack->id == $modpackItem->id ? 'is-active' : '' }}" href="{{ route('modpacks.show', $modpackItem) }}">
             @if($modpackItem->icon_path)
             <figure class="image is-64x64">
                 <img src="{{ $modpackItem->icon_url }}" />

--- a/routes/api.php
+++ b/routes/api.php
@@ -17,4 +17,4 @@ Route::group(['middleware' => 'auth:api', 'namespace' => 'Api'], function () {
 Route::get('verify/{token}', 'Api\VerifyToken');
 Route::get('modpack', 'Api\ModpackController@index');
 Route::get('modpack/{slug}', 'Api\ModpackController@show');
-Route::get('modpack/{slug}/{build}', 'Api\ModpackBuildController@show');
+Route::get('modpack/{slug}/{version}', 'Api\ModpackBuildController@show');

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,10 +16,12 @@ Route::post('/logout', 'Auth\LoginController@logout')->name('auth.logout');
 Route::middleware('auth')->group(function () {
     Route::get('/', 'DashboardController');
 
-    Route::get('/modpacks/{modpack}', 'ModpacksController@show');
-    Route::post('/modpacks', 'ModpacksController@store');
-    Route::patch('/modpacks/{modpack}', 'ModpacksController@update');
-    Route::delete('/modpacks/{modpack}', 'ModpacksController@destroy');
+    Route::resource('modpacks', 'ModpacksController')->only([
+        'show',
+        'store',
+        'update',
+        'destroy',
+    ]);
 
     Route::post('/modpacks/{modpack}/collaborators', 'ModpackCollaboratorsController@store');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,10 +27,12 @@ Route::middleware('auth')->group(function () {
 
     Route::delete('/collaborators/{collaborator}', 'CollaboratorsController@destroy');
 
-    Route::get('/modpacks/{modpack}/{build}', 'ModpackBuildsController@show');
-    Route::post('/modpacks/{modpack}/builds', 'ModpackBuildsController@store');
-    Route::post('/modpacks/{modpack}/{build}', 'ModpackBuildsController@update');
-    Route::delete('/modpacks/{modpack}/{build}', 'ModpackBuildsController@destroy');
+    Route::resource('modpacks/{modpack}/builds', 'ModpackBuildsController')->only([
+        'show',
+        'store',
+        'update',
+        'destroy',
+    ]);
 
     Route::get('/library', 'PackagesController@index');
     Route::get('/library/{package}', 'PackagesController@show');

--- a/tests/Feature/AddBundleTest.php
+++ b/tests/Feature/AddBundleTest.php
@@ -36,7 +36,7 @@ class AddBundleTest extends TestCase
             'release_id' => $release->id,
         ]);
 
-        $response->assertRedirect('/modpacks/iron-tanks/1.0.0');
+        $response->assertRedirect('/modpacks/iron-tanks/builds/1.0.0');
         $this->assertCount(1, Bundle::all());
         $this->assertTrue($build->fresh()->releases->first()->is($release));
     }
@@ -55,7 +55,7 @@ class AddBundleTest extends TestCase
             'release_id' => $release->id,
         ]);
 
-        $response->assertRedirect('/modpacks/iron-tanks/1.0.0');
+        $response->assertRedirect('/modpacks/iron-tanks/builds/1.0.0');
         $this->assertCount(1, Bundle::all());
         $this->assertTrue($build->fresh()->releases->first()->is($release));
     }

--- a/tests/Feature/DeleteBuildTest.php
+++ b/tests/Feature/DeleteBuildTest.php
@@ -29,7 +29,7 @@ class DeleteBuildTest extends TestCase
         $modpack->builds()->save(factory(Build::class)->make(['version' => '1.0.0']));
         $this->assertEquals(1, Build::count());
 
-        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/1.0.0');
+        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/builds/1.0.0');
 
         $response->assertRedirect('/modpacks/brothers-klaus');
         $this->assertEquals(0, Build::count());
@@ -45,7 +45,7 @@ class DeleteBuildTest extends TestCase
         $modpack->builds()->save(factory(Build::class)->make(['version' => '1.0.0']));
         $this->assertEquals(1, Build::count());
 
-        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/1.0.0');
+        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/builds/1.0.0');
 
         $response->assertRedirect('/modpacks/brothers-klaus');
         $this->assertEquals(0, Build::count());
@@ -60,7 +60,7 @@ class DeleteBuildTest extends TestCase
         $modpack->builds()->save(factory(Build::class)->make(['version' => '1.0.0']));
         $this->assertEquals(1, Build::count());
 
-        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/1.0.0');
+        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/builds/1.0.0');
 
         $response->assertStatus(403);
         $this->assertEquals(1, Build::count());
@@ -74,7 +74,7 @@ class DeleteBuildTest extends TestCase
         $modpack->builds()->save(factory(Build::class)->make(['version' => '1.0.0']));
         $this->assertEquals(1, Build::count());
 
-        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/1.0.0');
+        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/builds/1.0.0');
 
         $response->assertStatus(403);
         $this->assertEquals(1, Build::count());
@@ -87,7 +87,7 @@ class DeleteBuildTest extends TestCase
         $modpack->builds()->save(factory(Build::class)->make(['version' => '1.0.0']));
         $this->assertEquals(1, Build::count());
 
-        $response = $this->delete('/modpacks/brothers-klaus/1.0.0');
+        $response = $this->delete('/modpacks/brothers-klaus/builds/1.0.0');
 
         $response->assertRedirect('/login');
         $this->assertEquals(1, Build::count());
@@ -102,7 +102,7 @@ class DeleteBuildTest extends TestCase
         $modpack = factory(Modpack::class)->create(['slug' => 'brothers-klaus']);
         $build = factory(Build::class)->create(['modpack_id' => $modpack->id, 'version' => '1.0.0']);
 
-        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/1.0.0');
+        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/builds/1.0.0');
 
         $response->assertRedirect('/modpacks/brothers-klaus');
         $this->assertDatabaseHas('builds', ['id' => $otherBuild->id]);
@@ -115,7 +115,7 @@ class DeleteBuildTest extends TestCase
         $user = factory(User::class)->states('admin')->create();
         $modpack = factory(Modpack::class)->create(['slug' => 'brothers-klaus']);
 
-        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/invalid-build');
+        $response = $this->actingAs($user)->delete('/modpacks/brothers-klaus/builds/invalid-build');
 
         $response->assertStatus(404);
     }
@@ -127,7 +127,7 @@ class DeleteBuildTest extends TestCase
         $modpack = factory(Modpack::class)->create(['slug' => 'brothers-klaus']);
         $build = factory(Build::class)->create(['modpack_id' => $modpack->id, 'version' => '1.0.0']);
 
-        $response = $this->actingAs($user)->delete('/modpacks/invalid-modpack/1.0.0');
+        $response = $this->actingAs($user)->delete('/modpacks/invalid-modpack/builds/1.0.0');
 
         $response->assertStatus(404);
     }

--- a/tests/Feature/ShowBuildTest.php
+++ b/tests/Feature/ShowBuildTest.php
@@ -35,7 +35,7 @@ class ShowBuildTest extends TestCase
         $buildB = BuildFactory::createForModpack($modpackB, ['version' => '1.0.0']);
         $buildC = BuildFactory::createForModpack($modpackB, ['version' => '1.2.3']);
 
-        $response = $this->actingAs($user)->get('/modpacks/modpack-b/1.2.3');
+        $response = $this->actingAs($user)->get('/modpacks/modpack-b/builds/1.2.3');
 
         $response->assertStatus(200);
         $response->assertViewIs('builds.show');
@@ -48,7 +48,7 @@ class ShowBuildTest extends TestCase
         $modpack = factory(Modpack::class)->create(['slug' => 'example-modpack']);
         BuildFactory::createForModpack($modpack, ['version' => '1.2.3']);
 
-        $response = $this->get('/modpacks/example-modpack/1.2.3');
+        $response = $this->get('/modpacks/example-modpack/builds/1.2.3');
 
         $response->assertRedirect('/login');
     }
@@ -71,7 +71,7 @@ class ShowBuildTest extends TestCase
         $releaseA = factory(Release::class)->create(['package_id' => $packageA->id]);
         $build->releases()->attach($releaseA);
 
-        $response = $this->actingAs($user)->get('/modpacks/example-modpack/1.2.3');
+        $response = $this->actingAs($user)->get('/modpacks/example-modpack/builds/1.2.3');
 
         $response->data('build')->releases->assertEquals([
             $releaseA,
@@ -96,7 +96,7 @@ class ShowBuildTest extends TestCase
         $releaseB = factory(Release::class)->create(['package_id' => $packageB->id]);
         $buildB->releases()->attach($releaseB);
 
-        $response = $this->actingAs($user)->get('/modpacks/example-modpack/1.2.3');
+        $response = $this->actingAs($user)->get('/modpacks/example-modpack/builds/1.2.3');
 
         $response->data('build')->releases->assertContains($releaseA);
         $response->data('build')->releases->assertNotContains($releaseB);
@@ -108,7 +108,7 @@ class ShowBuildTest extends TestCase
         $user = factory(User::class)->create();
         factory(Build::class)->create(['version' => '1.2.3']);
 
-        $response = $this->actingAs($user)->get('/modpacks/fake-modpack/1.2.3');
+        $response = $this->actingAs($user)->get('/modpacks/fake-modpack/builds/1.2.3');
 
         $response->assertStatus(404);
     }
@@ -119,7 +119,7 @@ class ShowBuildTest extends TestCase
         $user = factory(User::class)->create();
         factory(Modpack::class)->create(['slug' => 'example-modpack']);
 
-        $response = $this->actingAs($user)->get('/modpacks/example-modpack/fake-version');
+        $response = $this->actingAs($user)->get('/modpacks/example-modpack/builds/fake-version');
 
         $response->assertStatus(404);
     }
@@ -135,7 +135,7 @@ class ShowBuildTest extends TestCase
         $packageB = factory(Package::class)->create(['name' => 'Package B']);
         $packageA = factory(Package::class)->create(['name' => 'Package A']);
 
-        $response = $this->actingAs($user)->get('/modpacks/example-modpack/1.2.3');
+        $response = $this->actingAs($user)->get('/modpacks/example-modpack/builds/1.2.3');
 
         $response->data('packages')->assertEquals([
             $packageA,
@@ -157,7 +157,7 @@ class ShowBuildTest extends TestCase
         $buildB = BuildFactory::createForModpack($modpack, ['version' => '1.0.0b']);
         $buildC = BuildFactory::createForModpack($modpack, ['version' => '10.5']);
 
-        $response = $this->actingAs($user)->get('/modpacks/example-modpack/1.0.0a');
+        $response = $this->actingAs($user)->get('/modpacks/example-modpack/builds/1.0.0a');
 
         $response->data('modpack')->builds->assertEquals([
             $buildC,

--- a/tests/Feature/ShowBuildTest.php
+++ b/tests/Feature/ShowBuildTest.php
@@ -143,26 +143,4 @@ class ShowBuildTest extends TestCase
             $packageC,
         ]);
     }
-
-    /** @test */
-    public function modpack_includes_builds_in_reverse_order()
-    {
-        $this->withoutExceptionHandling();
-
-        $user = factory(User::class)->create();
-        $modpack = factory(Modpack::class)->create([
-            'slug' => 'example-modpack',
-        ]);
-        $buildA = BuildFactory::createForModpack($modpack, ['version' => '1.0.0a']);
-        $buildB = BuildFactory::createForModpack($modpack, ['version' => '1.0.0b']);
-        $buildC = BuildFactory::createForModpack($modpack, ['version' => '10.5']);
-
-        $response = $this->actingAs($user)->get('/modpacks/example-modpack/builds/1.0.0a');
-
-        $response->data('modpack')->builds->assertEquals([
-            $buildC,
-            $buildB,
-            $buildA,
-        ]);
-    }
 }

--- a/tests/Feature/UpdateBuildTest.php
+++ b/tests/Feature/UpdateBuildTest.php
@@ -36,7 +36,7 @@ class UpdateBuildTest extends TestCase
         ]));
 
         $response = $this->actingAs($user)
-            ->post('/modpacks/brothers-klaus/1.2.3', [
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', [
                 'version' => '4.5.6',
                 'status' => 'public',
                 'minecraft_version' => '1.11.2',
@@ -46,7 +46,7 @@ class UpdateBuildTest extends TestCase
             ]);
 
         tap($build->fresh(), function ($build) use ($response) {
-            $response->assertRedirect('/modpacks/brothers-klaus/4.5.6');
+            $response->assertRedirect('/modpacks/brothers-klaus/builds/4.5.6');
 
             $this->assertEquals('4.5.6', $build->version);
             $this->assertEquals('public', $build->status);
@@ -67,7 +67,7 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->create($this->originalParams());
 
         $response = $this->actingAs($user)
-            ->post("modpacks/{$modpack->slug}/{$build->version}", $this->validParams());
+            ->patch("modpacks/{$modpack->slug}/builds/{$build->version}", $this->validParams());
 
         $response->assertRedirect();
         $this->assertArraySubset($this->validParams(), $build->fresh()->getAttributes());
@@ -82,7 +82,7 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->create($this->originalParams());
 
         $response = $this->actingAs($user)
-            ->post("modpacks/{$modpack->slug}/{$build->version}", $this->validParams());
+            ->patch("modpacks/{$modpack->slug}/builds/{$build->version}", $this->validParams());
 
         $response->assertStatus(403);
         $this->assertArraySubset($this->originalParams(), $build->fresh()->getAttributes());
@@ -96,7 +96,7 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->create($this->originalParams());
 
         $response = $this->actingAs($user)
-            ->post("modpacks/{$modpack->slug}/{$build->version}", $this->validParams());
+            ->patch("modpacks/{$modpack->slug}/builds/{$build->version}", $this->validParams());
 
         $response->assertStatus(403);
         $this->assertArraySubset($this->originalParams(), $build->fresh()->getAttributes());
@@ -108,7 +108,7 @@ class UpdateBuildTest extends TestCase
         $modpack = factory(Modpack::class)->create(['slug' => 'brothers-klaus']);
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams()));
 
-        $response = $this->post('/modpacks/brothers-klaus/1.2.3', $this->validParams());
+        $response = $this->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams());
 
         $response->assertRedirect('/login');
         $this->assertArraySubset($this->originalParams(), $build->fresh()->getAttributes());
@@ -122,12 +122,12 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->post('/modpacks/brothers-klaus/1.2.3', [
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', [
                 // empty set
             ]);
 
         $response->assertSessionMissing('errors');
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $this->assertArraySubset($this->originalParams(['version' => '1.2.3']), $build->fresh()->getAttributes());
     }
 
@@ -139,12 +139,12 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->from('/modpacks/brothers-klaus/1.2.3')
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->from('/modpacks/brothers-klaus/builds/1.2.3')
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'version' => '',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $response->assertSessionHasErrors('version');
         $this->assertArraySubset($this->originalParams(), $build->fresh()->getAttributes());
     }
@@ -157,12 +157,12 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->from('/modpacks/brothers-klaus/1.2.3')
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->from('/modpacks/brothers-klaus/builds/1.2.3')
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'minecraft_version' => '',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $response->assertSessionHasErrors('minecraft_version');
         $this->assertArraySubset($this->originalParams(), $build->fresh()->getAttributes());
     }
@@ -176,12 +176,12 @@ class UpdateBuildTest extends TestCase
         $buildB = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '4.5.6'])));
 
         $response = $this->actingAs($user)
-            ->from('/modpacks/brothers-klaus/1.2.3')
-            ->post('/modpacks/brothers-klaus/1.2.3', [
+            ->from('/modpacks/brothers-klaus/builds/1.2.3')
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', [
                 'version' => '4.5.6',
             ]);
 
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $response->assertSessionHasErrors('version');
         $this->assertArraySubset($this->originalParams(), $buildA->fresh()->getAttributes());
     }
@@ -194,11 +194,11 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'version' => '1.2.3',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $response->assertSessionMissing('errors');
         $this->assertArraySubset($this->validParams(['version' => '1.2.3']), $build->fresh()->getAttributes());
     }
@@ -213,12 +213,12 @@ class UpdateBuildTest extends TestCase
         $buildB = $modpackB->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '4.5.6'])));
 
         $response = $this->actingAs($user)
-            ->from('/modpacks/brothers-klaus/1.2.3')
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->from('/modpacks/brothers-klaus/builds/1.2.3')
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'version' => '4.5.6',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/4.5.6');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/4.5.6');
         $response->assertSessionMissing('errors');
         $this->assertArraySubset($this->validParams(['version' => '4.5.6']), $buildA->fresh()->getAttributes());
     }
@@ -231,12 +231,12 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->from('/modpacks/brothers-klaus/1.2.3')
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->from('/modpacks/brothers-klaus/builds/1.2.3')
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'status' => '',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $response->assertSessionHasErrors('status');
         $this->assertArraySubset($this->originalParams(), $build->fresh()->getAttributes());
     }
@@ -249,12 +249,12 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->from('/modpacks/brothers-klaus/1.2.3')
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->from('/modpacks/brothers-klaus/builds/1.2.3')
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'status' => 'invalid',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $response->assertSessionHasErrors('status');
         $this->assertArraySubset($this->originalParams(), $build->fresh()->getAttributes());
     }
@@ -267,11 +267,11 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'required_memory' => '',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/4.5.6');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/4.5.6');
         $response->assertSessionMissing('errors');
         $this->assertArraySubset($this->validParams(['required_memory' => '']), $build->fresh()->getAttributes());
     }
@@ -284,12 +284,12 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3', 'required_memory' => 1024])));
 
         $response = $this->actingAs($user)
-            ->from('/modpacks/brothers-klaus/1.2.3')
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->from('/modpacks/brothers-klaus/builds/1.2.3')
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'required_memory' => '2GB',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/1.2.3');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/1.2.3');
         $response->assertSessionHasErrors('required_memory');
         $this->assertArraySubset($this->originalParams(['required_memory' => 1024]), $build->fresh()->getAttributes());
     }
@@ -302,11 +302,11 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'java_version' => '',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/4.5.6');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/4.5.6');
         $response->assertSessionMissing('errors');
         $this->assertArraySubset($this->validParams(['java_version' => '']), $build->fresh()->getAttributes());
     }
@@ -319,11 +319,11 @@ class UpdateBuildTest extends TestCase
         $build = $modpack->builds()->save(factory(Build::class)->make($this->originalParams(['version' => '1.2.3'])));
 
         $response = $this->actingAs($user)
-            ->post('/modpacks/brothers-klaus/1.2.3', $this->validParams([
+            ->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams([
                 'forge_version' => '',
             ]));
 
-        $response->assertRedirect('/modpacks/brothers-klaus/4.5.6');
+        $response->assertRedirect('/modpacks/brothers-klaus/builds/4.5.6');
         $response->assertSessionMissing('errors');
         $this->assertArraySubset($this->validParams(['forge_version' => '']), $build->fresh()->getAttributes());
     }
@@ -339,7 +339,7 @@ class UpdateBuildTest extends TestCase
             'modpack_id' => $modpack->id,
         ]);
 
-        $response = $this->actingAs($user)->post('/modpacks/brothers-klaus/invalid-build', $this->validParams());
+        $response = $this->actingAs($user)->patch('/modpacks/brothers-klaus/builds/invalid-build', $this->validParams());
 
         $response->assertStatus(404);
     }
@@ -355,7 +355,7 @@ class UpdateBuildTest extends TestCase
             'modpack_id' => $modpack->id,
         ]);
 
-        $response = $this->actingAs($user)->post('/modpacks/invalid-modpack/1.2.3', $this->validParams());
+        $response = $this->actingAs($user)->patch('/modpacks/invalid-modpack/builds/1.2.3', $this->validParams());
 
         $response->assertStatus(404);
     }
@@ -370,7 +370,7 @@ class UpdateBuildTest extends TestCase
             'modpack_id' => '99',
         ]);
 
-        $response = $this->actingAs($user)->post('/modpacks/brothers-klaus/1.2.3', $this->validParams());
+        $response = $this->actingAs($user)->patch('/modpacks/brothers-klaus/builds/1.2.3', $this->validParams());
 
         $response->assertStatus(404);
     }

--- a/tests/Unit/BuildTest.php
+++ b/tests/Unit/BuildTest.php
@@ -41,4 +41,16 @@ class BuildTest extends TestCase
 
         $this->assertEquals('3 days ago', $build->created);
     }
+
+    /** @test **/
+    public function can_get_build_from_modpack_slug_and_build_version()
+    {
+        $otherBuild = factory(Build::class)->create(['version' => '1.2.3']);
+        $modpack = factory(Modpack::class)->create(['slug' => 'b-team']);
+        $build = factory(Build::class)->create(['modpack_id' => $modpack->id, 'version' => '1.2.3']);
+
+        $result = Build::findByModpackSlugAndBuildVersion('b-team', '1.2.3');
+
+        $this->assertTrue($result->is($build));
+    }
 }


### PR DESCRIPTION
Route model binding allows the model requested in a route to be injected directly into a controller method. This primarily helps to clean up controller actions by de-duplicating simple select queries and 404 errors. 