### PR TITLE
Update InstallCommand.php

### DIFF
--- a/app/Console/Commands/InstallCommand.php
+++ b/app/Console/Commands/InstallCommand.php
@@ -108,7 +108,7 @@ class InstallCommand extends Command
     private function generateApiKey()
     {
         if ($this->confirm('Do you want to generate new API keys?', true)) {
-            $this->call('passport:install', ['--force' => true])) 
+            $this->call('passport:install', ['--force' => true]);
         }
     }
 


### PR DESCRIPTION
Replace `)` with a semicolon.

Previously caused an error:
![Error](https://i.imgur.com/Le6tyPR.png)