### PR TITLE
Remove php 7.0.0 platform restriction

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -62,9 +62,6 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true,
-        "platform": {
-            "php": "7.0.0"
-        }
+        "optimize-autoloader": true
     }
 }


### PR DESCRIPTION
I had set this to keep the dependencies back on versions which were compatible with php 7.0.0, but thats proving to be an issue in its own right. 

PHP 7.0.0 is out of active support at this point, so I think we can safely move forward. I'll hold this PR here for a bit to see if anybody has any feedback before I merge it in. 