### PR TITLE
Upload Functionality (jar files) & Forge "caching"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 _ide_helper.php
 npm-debug.log
 yarn-error.log
+package-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ _ide_helper.php
 npm-debug.log
 yarn-error.log
 package-lock.json
+composer.lock

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -52,18 +52,28 @@ class ModpackBuildController extends Controller
                 'error' => 'Build does not exist',
             ], 404);
         }
+        if(isset($build->forge_version)){
+                $forge = [
+                    'name' => 'Forge',
+                    'version' => $build->forge_version,
+                    'md5' => url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip",
+                    'url' => url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"
+                ];
+       }else{
+
+           $forge = "";
+       }
+
+
+
+
 
         return response()->json([
             'minecraft' => $build->minecraft_version,
             'java' => $build->java_version,
             'memory' => (int) $build->required_memory,
             'forge' => $build->forge_version,
-            'mods' => //[
-            //     'name' => 'Forge',
-            //     'version' => $build->forge_version,
-            //     //'md5' => FileHash::hash($forge_download_url),
-            //     'url' => $forge_download_url
-            // ],
+            'mods' => $forge,
             $build->releases->transform(function ($release) {
                 return [
                     'name' => $release->package->name,

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -17,7 +17,6 @@ use App\Facades\FileHash;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Storage;
 
-
 class ModpackBuildController extends Controller
 {
     /**

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -62,7 +62,7 @@ class ModpackBuildController extends Controller
                     'name' => $release->package->name,
                     'version' => $release->version,
                     'md5' => $release->md5,
-                    'url' => Storage::url($release->path),
+                    'url' => $release->url,
                 ];
             }),
         ]);

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -72,10 +72,6 @@ class ModpackBuildController extends Controller
            );
        }
 
-       //$mods_list = array_merge($forge, $mods);
-
-       //dd($mods);
-
 
 
         return response()->json([

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -53,27 +53,25 @@ class ModpackBuildController extends Controller
                 'error' => 'Build does not exist',
             ], 404);
         }
-        if (isset($build->forge_version)){
+        if (isset($build->forge_version)) {
             $mods[] = [
                 'name' => 'Forge',
                 'version' => $build->forge_version,
-                'md5' => FileHash::hash(url('/storage/forge/')."/".$build->minecraft_version."-".$build->forge_version.".zip"),
-                'url' => url('/storage/forge/')."/".$build->minecraft_version."-".$build->forge_version.".zip"
+                'md5' => FileHash::hash(url('/storage/forge/').'/'.$build->minecraft_version.'-'.$build->forge_version.'.zip'),
+                'url' => url('/storage/forge/').'/'.$build->minecraft_version.'-'.$build->forge_version.'.zip',
             ];
        }
 
 
 
-       foreach ($build->releases as $release){
-           $mods[] = [
-               'name' => $release->package->name,
-               'version' => $release->version,
-               'md5' => $release->md5,
-               'url' => $release->url,
-           ];
-       }
-
-
+        foreach ($build->releases as $release) {
+            $mods[] = [
+                'name' => $release->package->name,
+                'version' => $release->version,
+                'md5' => $release->md5,
+                'url' => $release->url,
+            ];
+        }
 
         return response()->json([
             'minecraft' => $build->minecraft_version,

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -53,27 +53,23 @@ class ModpackBuildController extends Controller
                 'error' => 'Build does not exist',
             ], 404);
         }
-        if (isset($build->forge_version)){
+        if (isset($build->forge_version)) {
             $mods[] = [
                 'name' => 'Forge',
                 'version' => $build->forge_version,
-                'md5' => FileHash::hash(url('/storage/forge/')."/".$build->minecraft_version."-".$build->forge_version.".zip"),
-                'url' => url('/storage/forge/')."/".$build->minecraft_version."-".$build->forge_version.".zip"
+                'md5' => FileHash::hash(url('/storage/forge/').'/'.$build->minecraft_version.'-'.$build->forge_version.'.zip'),
+                'url' => url('/storage/forge/').'/'.$build->minecraft_version.'-'.$build->forge_version.'.zip',
             ];
        }
 
-
-
-       foreach ($build->releases as $release){
-           $mods[] = [
-               'name' => $release->package->name,
-               'version' => $release->version,
-               'md5' => $release->md5,
-               'url' => $release->url,
-           ];
-       }
-
-
+        foreach ($build->releases as $release) {
+            $mods[] = [
+                'name' => $release->package->name,
+                'version' => $release->version,
+                'md5' => $release->md5,
+                'url' => $release->url,
+            ];
+        }
 
         return response()->json([
             'minecraft' => $build->minecraft_version,

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -62,11 +62,6 @@ class ModpackBuildController extends Controller
             ];
        }
 
-<<<<<<< HEAD
-=======
-
-
->>>>>>> 13358b6935f1a9e26eaff2dc28eadfd3e69d7480
         foreach ($build->releases as $release) {
             $mods[] = [
                 'name' => $release->package->name,

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -60,7 +60,7 @@ class ModpackBuildController extends Controller
                 'md5' => FileHash::hash(url('/storage/forge/').'/'.$build->minecraft_version.'-'.$build->forge_version.'.zip'),
                 'url' => url('/storage/forge/').'/'.$build->minecraft_version.'-'.$build->forge_version.'.zip',
             ];
-       }
+        }
 
         foreach ($build->releases as $release) {
             $mods[] = [

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -53,18 +53,28 @@ class ModpackBuildController extends Controller
             ], 404);
         }
         if(isset($build->forge_version)){
-                $forge = [
+                $mods[] = array(
                     'name' => 'Forge',
                     'version' => $build->forge_version,
-                    'md5' => url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip",
+                    'md5' => FileHash::hash(url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"),
                     'url' => url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"
-                ];
-       }else{
-
-           $forge = "";
+                );
        }
 
 
+
+       foreach($build->releases as $release){
+           $mods[] = array(
+               'name' => $release->package->name,
+               'version' => $release->version,
+               'md5' => $release->md5,
+               'url' => $release->url,
+           );
+       }
+
+       //$mods_list = array_merge($forge, $mods);
+
+       //dd($mods);
 
 
 
@@ -73,15 +83,7 @@ class ModpackBuildController extends Controller
             'java' => $build->java_version,
             'memory' => (int) $build->required_memory,
             'forge' => $build->forge_version,
-            'mods' => $forge,
-            $build->releases->transform(function ($release) {
-                return [
-                    'name' => $release->package->name,
-                    'version' => $release->version,
-                    'md5' => $release->md5,
-                    'url' => $release->url,
-                ];
-            }),
+            'mods' => $mods
         ]);
     }
 }

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -13,9 +13,10 @@ namespace App\Http\Controllers\Api;
 
 use App\Build;
 use App\Modpack;
+use App\Facades\FileHash;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Storage;
-use App\Facades\FileHash;
+
 
 class ModpackBuildController extends Controller
 {
@@ -53,12 +54,12 @@ class ModpackBuildController extends Controller
             ], 404);
         }
         if(isset($build->forge_version)){
-                $mods[] = array(
-                    'name' => 'Forge',
-                    'version' => $build->forge_version,
-                    'md5' => FileHash::hash(url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"),
-                    'url' => url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"
-                );
+            $mods[] = [
+                'name' => 'Forge',
+                'version' => $build->forge_version,
+                'md5' => FileHash::hash(url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"),
+                'url' => url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"
+            ];
        }
 
 
@@ -79,7 +80,7 @@ class ModpackBuildController extends Controller
             'java' => $build->java_version,
             'memory' => (int) $build->required_memory,
             'forge' => $build->forge_version,
-            'mods' => $mods
+            'mods' => $mods,
         ]);
     }
 }

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -15,6 +15,7 @@ use App\Build;
 use App\Modpack;
 use App\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Storage;
+use App\Facades\FileHash;
 
 class ModpackBuildController extends Controller
 {
@@ -57,7 +58,13 @@ class ModpackBuildController extends Controller
             'java' => $build->java_version,
             'memory' => (int) $build->required_memory,
             'forge' => $build->forge_version,
-            'mods' => $build->releases->transform(function ($release) {
+            'mods' => //[
+            //     'name' => 'Forge',
+            //     'version' => $build->forge_version,
+            //     //'md5' => FileHash::hash($forge_download_url),
+            //     'url' => $forge_download_url
+            // ],
+            $build->releases->transform(function ($release) {
                 return [
                     'name' => $release->package->name,
                     'version' => $release->version,

--- a/app/Http/Controllers/Api/ModpackBuildController.php
+++ b/app/Http/Controllers/Api/ModpackBuildController.php
@@ -53,24 +53,24 @@ class ModpackBuildController extends Controller
                 'error' => 'Build does not exist',
             ], 404);
         }
-        if(isset($build->forge_version)){
+        if (isset($build->forge_version)){
             $mods[] = [
                 'name' => 'Forge',
                 'version' => $build->forge_version,
-                'md5' => FileHash::hash(url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"),
-                'url' => url('/storage/forge/') . "/" . $build->minecraft_version . "-" . $build->forge_version . ".zip"
+                'md5' => FileHash::hash(url('/storage/forge/')."/".$build->minecraft_version."-".$build->forge_version.".zip"),
+                'url' => url('/storage/forge/')."/".$build->minecraft_version."-".$build->forge_version.".zip"
             ];
        }
 
 
 
-       foreach($build->releases as $release){
-           $mods[] = array(
+       foreach ($build->releases as $release){
+           $mods[] = [
                'name' => $release->package->name,
                'version' => $release->version,
                'md5' => $release->md5,
                'url' => $release->url,
-           );
+           ];
        }
 
 

--- a/app/Http/Controllers/ForgeController.php
+++ b/app/Http/Controllers/ForgeController.php
@@ -21,17 +21,17 @@ class ForgeController extends Controller
 
         $forge_versions = $forge_json->versioning->versions->version;
         $forge_version_list = [];
-        foreach ($forge_versions as $version){
+        foreach ($forge_versions as $version) {
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];
         }
         $mcversions = [];
-        foreach ($forge_version_list as $mc => $forge){
+        foreach ($forge_version_list as $mc => $forge) {
             $mcversions[] = $mc;
         }
         $mcversions = array_reverse($mcversions);
+        
         return response()->json($mcversions);
-
     }
     public function getForgeVersions($mcversion)
     {
@@ -40,11 +40,12 @@ class ForgeController extends Controller
 
         $forge_versions = $forge_json->versioning->versions->version;
         $forge_version_list = [];
-        foreach ($forge_versions as $version){
+        foreach ($forge_versions as $version) {
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];
         }
         $forge_version_list = array_reverse($forge_version_list[$mcversion]);
+
         return response()->json($forge_version_list);
     }
 }

--- a/app/Http/Controllers/ForgeController.php
+++ b/app/Http/Controllers/ForgeController.php
@@ -14,18 +14,19 @@ namespace App\Http\Controllers;
 class ForgeController extends Controller
 {
 
-    public function getMcVersions(){
+    public function getMcVersions()
+    {
         $forge_xml = simplexml_load_file('http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml');
         $forge_json = json_decode(json_encode($forge_xml));
 
-        $forge_versions  = $forge_json->versioning->versions->version;
-        $forge_version_list = array();
-        foreach($forge_versions as $version){
+        $forge_versions = $forge_json->versioning->versions->version;
+        $forge_version_list = [];
+        foreach ($forge_versions as $version){
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];
         }
         $mcversions = [];
-        foreach($forge_version_list as $mc => $forge){
+        foreach ($forge_version_list as $mc => $forge){
             $mcversions[] = $mc;
         }
         $mcversions = array_reverse($mcversions);
@@ -37,9 +38,9 @@ class ForgeController extends Controller
         $forge_xml = simplexml_load_file('http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml');
         $forge_json = json_decode(json_encode($forge_xml));
 
-        $forge_versions  = $forge_json->versioning->versions->version;
+        $forge_versions = $forge_json->versioning->versions->version;
         $forge_version_list = [];
-        foreach($forge_versions as $version){
+        foreach ($forge_versions as $version){
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];
         }

--- a/app/Http/Controllers/ForgeController.php
+++ b/app/Http/Controllers/ForgeController.php
@@ -21,18 +21,19 @@ class ForgeController extends Controller
 
         $forge_versions = $forge_json->versioning->versions->version;
         $forge_version_list = [];
-        foreach ($forge_versions as $version){
+        foreach ($forge_versions as $version) {
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];
         }
         $mcversions = [];
-        foreach ($forge_version_list as $mc => $forge){
+        foreach ($forge_version_list as $mc => $forge) {
             $mcversions[] = $mc;
         }
         $mcversions = array_reverse($mcversions);
-        return response()->json($mcversions);
 
+        return response()->json($mcversions);
     }
+
     public function getForgeVersions($mcversion)
     {
         $forge_xml = simplexml_load_file('http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml');
@@ -40,11 +41,12 @@ class ForgeController extends Controller
 
         $forge_versions = $forge_json->versioning->versions->version;
         $forge_version_list = [];
-        foreach ($forge_versions as $version){
+        foreach ($forge_versions as $version) {
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];
         }
         $forge_version_list = array_reverse($forge_version_list[$mcversion]);
+
         return response()->json($forge_version_list);
     }
 }

--- a/app/Http/Controllers/ForgeController.php
+++ b/app/Http/Controllers/ForgeController.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Http\Controllers;
+
+class ForgeController extends Controller
+{
+
+    public function getMcVersions(){
+        $forge_xml = simplexml_load_file("http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml");
+        $forge_json = json_decode(json_encode($forge_xml));
+
+        $forge_versions  = $forge_json->versioning->versions->version;
+        $forge_version_list = array();
+        foreach($forge_versions as $version){
+            $explode = explode('-', $version, 2);
+            $forge_version_list[$explode[0]][] = $explode[1];
+        }
+        $mcversions = array();
+        foreach($forge_version_list as $mc => $forge){
+            $mcversions[] = $mc;
+        }
+        $mcversions = array_reverse($mcversions);
+        return response()->json($mcversions);
+
+    }
+    public function getForgeVersions($mcversion)
+    {
+        $forge_xml = simplexml_load_file("http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml");
+        $forge_json = json_decode(json_encode($forge_xml));
+
+        $forge_versions  = $forge_json->versioning->versions->version;
+        $forge_version_list = array();
+        foreach($forge_versions as $version){
+            $explode = explode('-', $version, 2);
+            $forge_version_list[$explode[0]][] = $explode[1];
+        }
+        $forge_version_list = array_reverse($forge_version_list[$mcversion]);
+        return response()->json($forge_version_list);
+    }
+}

--- a/app/Http/Controllers/ForgeController.php
+++ b/app/Http/Controllers/ForgeController.php
@@ -30,11 +30,7 @@ class ForgeController extends Controller
             $mcversions[] = $mc;
         }
         $mcversions = array_reverse($mcversions);
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 13358b6935f1a9e26eaff2dc28eadfd3e69d7480
         return response()->json($mcversions);
     }
 

--- a/app/Http/Controllers/ForgeController.php
+++ b/app/Http/Controllers/ForgeController.php
@@ -15,7 +15,7 @@ class ForgeController extends Controller
 {
 
     public function getMcVersions(){
-        $forge_xml = simplexml_load_file("http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml");
+        $forge_xml = simplexml_load_file('http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml');
         $forge_json = json_decode(json_encode($forge_xml));
 
         $forge_versions  = $forge_json->versioning->versions->version;
@@ -24,7 +24,7 @@ class ForgeController extends Controller
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];
         }
-        $mcversions = array();
+        $mcversions = [];
         foreach($forge_version_list as $mc => $forge){
             $mcversions[] = $mc;
         }
@@ -34,11 +34,11 @@ class ForgeController extends Controller
     }
     public function getForgeVersions($mcversion)
     {
-        $forge_xml = simplexml_load_file("http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml");
+        $forge_xml = simplexml_load_file('http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml');
         $forge_json = json_decode(json_encode($forge_xml));
 
         $forge_versions  = $forge_json->versioning->versions->version;
-        $forge_version_list = array();
+        $forge_version_list = [];
         foreach($forge_versions as $version){
             $explode = explode('-', $version, 2);
             $forge_version_list[$explode[0]][] = $explode[1];

--- a/app/Http/Controllers/ForgeController.php
+++ b/app/Http/Controllers/ForgeController.php
@@ -13,7 +13,6 @@ namespace App\Http\Controllers;
 
 class ForgeController extends Controller
 {
-
     public function getMcVersions()
     {
         $forge_xml = simplexml_load_file('http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml');

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -120,7 +120,7 @@ class ModpackBuildsController extends Controller
 
         $file_name = request()->input('minecraft_version') . "-" . request()->input('forge_version');
         if(!Storage::exists("forge/". $file_name . ".zip")){
-                    
+
             $forge_download = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/". $file_name . "/forge-" . $file_name . "-universal.jar";
 
 
@@ -137,7 +137,6 @@ class ModpackBuildsController extends Controller
             $archive_path = storage_path("app/public/forge/");
 
             if($archive->open($archive_path . $file_name . ".zip", ZipArchive::CREATE) === TRUE){
-                //print_r(storage_path("/app/public/") . $tmp_file);
                 $archive->addFile(storage_path("/app/public/") . $tmp_file, "bin/modpack.jar");
             }
             $archive->close();

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -127,7 +127,6 @@ class ModpackBuildsController extends Controller
             Storage::disk('public')->put('/tmp/'.$file_name.'.jar', $contents);
             $tmp_file = 'tmp/'.$file_name.'.jar';
 
-<
                 Storage::makeDirectory("forge");
 
             }

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -18,9 +18,6 @@ use App\Package;
 
 use Illuminate\Validation\Rule;
 
-
-
-
 class ModpackBuildsController extends Controller
 {
     /**

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -10,6 +10,7 @@
  */
 
 namespace App\Http\Controllers;
+
 use Storage;
 use App\Build;
 use ZipArchive;
@@ -43,8 +44,6 @@ class ModpackBuildsController extends Controller
             ->where('modpack_id', $modpack->id)
             ->where('version', $buildVersion)
             ->firstOrFail();
-
-
 
         return view('builds.show', [
             'modpack' => $modpack,
@@ -116,29 +115,27 @@ class ModpackBuildsController extends Controller
             'required_memory' => ['nullable', 'numeric'],
         ]);
 
-        $file_name = request()->input('minecraft_version')."-".request()->input('forge_version');
+        $file_name = request()->input('minecraft_version').'-'.request()->input('forge_version');
         if(! Storage::exists("forge/".$file_name.".zip")){
-
-            $forge_download = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/".$file_name."/forge-".$file_name."-universal.jar";
-
+            $forge_download = 'http://files.minecraftforge.net/maven/net/minecraftforge/forge/'.$file_name.'/forge-'.$file_name.'-universal.jar';
 
             $contents = file_get_contents($forge_download);
 
 
-            Storage::disk('public')->put("/tmp/".$file_name.".jar", $contents);
-            $tmp_file = "tmp/" . $file_name . ".jar";
+            Storage::disk('public')->put('/tmp/'.$file_name.'.jar', $contents);
+            $tmp_file = 'tmp/'.$file_name.'.jar';
 
-            if(! Storage::exists("forge")) {
+            if (! Storage::exists("forge")) {
                 Storage::makeDirectory("forge");
             }
             $archive = new ZipArchive();
-            $archive_path = storage_path("app/public/forge/");
+            $archive_path = storage_path('app/public/forge/');
 
-            if($archive->open($archive_path.$file_name.".zip", ZipArchive::CREATE) === TRUE){
-                $archive->addFile(storage_path("/app/public/") . $tmp_file, "bin/modpack.jar");
-            }
+            if ($archive->open($archive_path.$file_name.'.zip', ZipArchive::CREATE) === true) {
+                $archive->addFile(storage_path('/app/public/').$tmp_file, 'bin/modpack.jar');
+             }
             $archive->close();
-            Storage::disk('public')->delete("tmp/".$file_name);
+            Storage::disk('public')->delete('tmp/'.$file_name);
         }
 
         $build->update(request()->only([

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of Solder.
  *
@@ -7,13 +8,16 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace App\Http\Controllers;
+
 use Storage;
 use App\Build;
 use ZipArchive;
 use App\Modpack;
 use App\Package;
 use Illuminate\Validation\Rule;
+
 class ModpackBuildsController extends Controller
 {
     /**
@@ -38,6 +42,7 @@ class ModpackBuildsController extends Controller
             ->where('modpack_id', $modpack->id)
             ->where('version', $buildVersion)
             ->firstOrFail();
+
         return view('builds.show', [
             'modpack' => $modpack,
             'build' => $build,
@@ -76,8 +81,10 @@ class ModpackBuildsController extends Controller
                 $build->releases()->attach($release);
             });
         }
+
         return redirect("/modpacks/$modpackSlug");
     }
+
     /**
      * Update a build.
      *
@@ -97,22 +104,22 @@ class ModpackBuildsController extends Controller
             'minecraft_version' => ['sometimes', 'required'],
             'required_memory' => ['nullable', 'numeric'],
         ]);
-        $file_name = request()->input('minecraft_version')."-".request()->input('forge_version');
-        if (! Storage::exists("forge/".$file_name.".zip")) {
-            $forge_download = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/".$file_name."/forge-".$file_name."-universal.jar";
+        $file_name = request()->input('minecraft_version').'-'.request()->input('forge_version');
+        if (! Storage::exists('forge/'.$file_name.'.zip')) {
+            $forge_download = 'http://files.minecraftforge.net/maven/net/minecraftforge/forge/'.$file_name.'/forge-'.$file_name.'-universal.jar';
             $contents = file_get_contents($forge_download);
-            Storage::disk('public')->put("/tmp/".$file_name.".jar", $contents);
-            $tmp_file = "tmp/" . $file_name . ".jar";
-            if(! Storage::exists("forge")) {
-                Storage::makeDirectory("forge");
+            Storage::disk('public')->put('/tmp/'.$file_name.'.jar', $contents);
+            $tmp_file = 'tmp/'.$file_name.'.jar';
+            if (! Storage::exists('forge')) {
+                Storage::makeDirectory('forge');
             }
             $archive = new ZipArchive();
-            $archive_path = storage_path("app/public/forge/");
-            if ($archive->open($archive_path.$file_name.".zip", ZipArchive::CREATE) === true) {
-                $archive->addFile(storage_path("/app/public/") . $tmp_file, "bin/modpack.jar");
+            $archive_path = storage_path('app/public/forge/');
+            if ($archive->open($archive_path.$file_name.'.zip', ZipArchive::CREATE) === true) {
+                $archive->addFile(storage_path('/app/public/') . $tmp_file, 'bin/modpack.jar');
             }
             $archive->close();
-            Storage::disk('public')->delete("tmp/".$file_name);
+            Storage::disk('public')->delete('tmp/'.$file_name);
         }
         $build->update(request()->only([
             'version',
@@ -122,8 +129,10 @@ class ModpackBuildsController extends Controller
             'required_memory',
             'forge_version',
         ]));
+
         return redirect("/modpacks/$modpackSlug/{$build->version}");
     }
+
     /**
      * Remove build from application.
      *
@@ -140,6 +149,7 @@ class ModpackBuildsController extends Controller
             ->where('modpack_id', $modpack->id)
             ->firstOrFail();
         $build->delete();
+
         return redirect("/modpacks/$modpackSlug");
     }
 }

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -10,15 +10,16 @@
  */
 
 namespace App\Http\Controllers;
-
+use Storage;
 use App\Build;
+use ZipArchive;
 use App\Modpack;
 use App\Package;
 
 use Illuminate\Validation\Rule;
 
-use Storage;
-use ZipArchive;
+
+
 
 class ModpackBuildsController extends Controller
 {
@@ -118,29 +119,29 @@ class ModpackBuildsController extends Controller
             'required_memory' => ['nullable', 'numeric'],
         ]);
 
-        $file_name = request()->input('minecraft_version') . "-" . request()->input('forge_version');
-        if(!Storage::exists("forge/". $file_name . ".zip")){
+        $file_name = request()->input('minecraft_version')."-".request()->input('forge_version');
+        if(! Storage::exists("forge/".$file_name.".zip")){
 
-            $forge_download = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/". $file_name . "/forge-" . $file_name . "-universal.jar";
+            $forge_download = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/".$file_name."/forge-".$file_name."-universal.jar";
 
 
             $contents = file_get_contents($forge_download);
 
 
-            Storage::disk('public')->put("/tmp/" .  $file_name . ".jar", $contents);
+            Storage::disk('public')->put("/tmp/".$file_name.".jar", $contents);
             $tmp_file = "tmp/" . $file_name . ".jar";
 
-            if(!Storage::exists("forge")) {
+            if(! Storage::exists("forge")) {
                 Storage::makeDirectory("forge");
             }
             $archive = new ZipArchive();
             $archive_path = storage_path("app/public/forge/");
 
-            if($archive->open($archive_path . $file_name . ".zip", ZipArchive::CREATE) === TRUE){
+            if($archive->open($archive_path.$file_name.".zip", ZipArchive::CREATE) === TRUE){
                 $archive->addFile(storage_path("/app/public/") . $tmp_file, "bin/modpack.jar");
             }
             $archive->close();
-            Storage::disk('public')->delete("tmp/" . $file_name);
+            Storage::disk('public')->delete("tmp/".$file_name);
         }
 
         $build->update(request()->only([

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -42,6 +42,8 @@ class ModpackBuildsController extends Controller
             ->where('version', $buildVersion)
             ->firstOrFail();
 
+            
+
         return view('builds.show', [
             'modpack' => $modpack,
             'build' => $build,
@@ -99,6 +101,7 @@ class ModpackBuildsController extends Controller
      */
     public function update($modpackSlug, $buildVersion)
     {
+
         $modpack = Modpack::where('slug', $modpackSlug)->firstOrFail();
         $build = $modpack->builds()->where('version', $buildVersion)->firstOrFail();
 

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -10,6 +10,7 @@
  */
 
 namespace App\Http\Controllers;
+
 use Storage;
 use App\Build;
 use ZipArchive;
@@ -43,8 +44,6 @@ class ModpackBuildsController extends Controller
             ->where('modpack_id', $modpack->id)
             ->where('version', $buildVersion)
             ->firstOrFail();
-
-
 
         return view('builds.show', [
             'modpack' => $modpack,
@@ -116,29 +115,27 @@ class ModpackBuildsController extends Controller
             'required_memory' => ['nullable', 'numeric'],
         ]);
 
-        $file_name = request()->input('minecraft_version')."-".request()->input('forge_version');
-        if(! Storage::exists("forge/".$file_name.".zip")){
-
-            $forge_download = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/".$file_name."/forge-".$file_name."-universal.jar";
-
+        $file_name = request()->input('minecraft_version').'-'.request()->input('forge_version');
+        if (! Storage::exists("forge/".$file_name.".zip")){
+            $forge_download = 'http://files.minecraftforge.net/maven/net/minecraftforge/forge/'.$file_name.'/forge-'.$file_name.'-universal.jar';
 
             $contents = file_get_contents($forge_download);
 
 
-            Storage::disk('public')->put("/tmp/".$file_name.".jar", $contents);
-            $tmp_file = "tmp/" . $file_name . ".jar";
+            Storage::disk('public')->put('/tmp/'.$file_name.'.jar', $contents);
+            $tmp_file = 'tmp/'.$file_name.'.jar';
 
-            if(! Storage::exists("forge")) {
-                Storage::makeDirectory("forge");
+            if (! Storage::exists('forge')) {
+                Storage::makeDirectory('forge');
             }
             $archive = new ZipArchive();
-            $archive_path = storage_path("app/public/forge/");
+            $archive_path = storage_path('app/public/forge/');
 
-            if($archive->open($archive_path.$file_name.".zip", ZipArchive::CREATE) === TRUE){
-                $archive->addFile(storage_path("/app/public/") . $tmp_file, "bin/modpack.jar");
+            if ($archive->open($archive_path.$file_name.'.zip', ZipArchive::CREATE) === true) {
+                $archive->addFile(storage_path('/app/public/').$tmp_file, 'bin/modpack.jar');
             }
             $archive->close();
-            Storage::disk('public')->delete("tmp/".$file_name);
+            Storage::disk('public')->delete('tmp/'.$file_name);
         }
 
         $build->update(request()->only([

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of Solder.
  *
@@ -8,17 +7,13 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace App\Http\Controllers;
-
 use Storage;
 use App\Build;
 use ZipArchive;
 use App\Modpack;
 use App\Package;
-
 use Illuminate\Validation\Rule;
-
 class ModpackBuildsController extends Controller
 {
     /**
@@ -36,7 +31,6 @@ class ModpackBuildsController extends Controller
                 $query->orderBy('version', 'desc');
             }])
             ->firstOrFail();
-
         $build = Build::with(['releases.package', 'releases' => function ($query) {
             $query->join('packages', 'releases.package_id', '=', 'packages.id')
                 ->orderBy('packages.name');
@@ -44,14 +38,12 @@ class ModpackBuildsController extends Controller
             ->where('modpack_id', $modpack->id)
             ->where('version', $buildVersion)
             ->firstOrFail();
-
         return view('builds.show', [
             'modpack' => $modpack,
             'build' => $build,
             'packages' => Package::orderBy('name')->get(),
         ]);
     }
-
     /**
      * Store the passed data as a build.
      *
@@ -62,9 +54,7 @@ class ModpackBuildsController extends Controller
     public function store($modpackSlug)
     {
         $modpack = Modpack::where('slug', $modpackSlug)->first();
-
         $this->authorize('update', $modpack);
-
         request()->validate([
             'version' => ['required', 'regex:/^[a-zA-Z0-9_-][.a-zA-Z0-9_-]*$/', Rule::unique('builds')->where('modpack_id', $modpack->id)],
             'minecraft_version' => ['required'],
@@ -72,7 +62,6 @@ class ModpackBuildsController extends Controller
             'required_memory' => ['nullable', 'numeric'],
             'clone_build_id' => ['nullable', Rule::exists('builds', 'id')->where('modpack_id', $modpack->id)],
         ]);
-
         $build = $modpack->builds()->create([
             'version' => request('version'),
             'minecraft_version' => request('minecraft_version'),
@@ -81,17 +70,14 @@ class ModpackBuildsController extends Controller
             'required_memory' => request('required_memory'),
             'forge_version' => request('forge_version'),
         ]);
-
         if (request('clone_build_id') !== null) {
             $templateBuild = Build::find(request('clone_build_id'));
             $templateBuild->releases->each(function ($release) use ($build) {
                 $build->releases()->attach($release);
             });
         }
-
         return redirect("/modpacks/$modpackSlug");
     }
-
     /**
      * Update a build.
      *
@@ -102,46 +88,32 @@ class ModpackBuildsController extends Controller
      */
     public function update($modpackSlug, $buildVersion)
     {
-
         $modpack = Modpack::where('slug', $modpackSlug)->firstOrFail();
         $build = $modpack->builds()->where('version', $buildVersion)->firstOrFail();
-
         $this->authorize('update', $modpack);
-
         request()->validate([
             'version' => ['sometimes', 'required', Rule::unique('builds')->ignore($build->id)->where('modpack_id', $modpack->id)],
             'status' => ['sometimes', 'required', 'in:public,private,draft'],
             'minecraft_version' => ['sometimes', 'required'],
             'required_memory' => ['nullable', 'numeric'],
         ]);
-
-        $file_name = request()->input('minecraft_version').'-'.request()->input('forge_version');
-
-        if (! Storage::exists("forge/".$file_name.".zip")){
-
-            $forge_download = 'http://files.minecraftforge.net/maven/net/minecraftforge/forge/'.$file_name.'/forge-'.$file_name.'-universal.jar';
-
+        $file_name = request()->input('minecraft_version')."-".request()->input('forge_version');
+        if (! Storage::exists("forge/".$file_name.".zip")) {
+            $forge_download = "http://files.minecraftforge.net/maven/net/minecraftforge/forge/".$file_name."/forge-".$file_name."-universal.jar";
             $contents = file_get_contents($forge_download);
-
-
-            Storage::disk('public')->put('/tmp/'.$file_name.'.jar', $contents);
-            $tmp_file = 'tmp/'.$file_name.'.jar';
-
+            Storage::disk('public')->put("/tmp/".$file_name.".jar", $contents);
+            $tmp_file = "tmp/" . $file_name . ".jar";
+            if(! Storage::exists("forge")) {
                 Storage::makeDirectory("forge");
-
             }
             $archive = new ZipArchive();
-            $archive_path = storage_path('app/public/forge/');
-
-            if ($archive->open($archive_path.$file_name.'.zip', ZipArchive::CREATE) === true) {
-                $archive->addFile(storage_path('/app/public/').$tmp_file, 'bin/modpack.jar');
-
+            $archive_path = storage_path("app/public/forge/");
+            if ($archive->open($archive_path.$file_name.".zip", ZipArchive::CREATE) === true) {
+                $archive->addFile(storage_path("/app/public/") . $tmp_file, "bin/modpack.jar");
             }
-
             $archive->close();
-            Storage::disk('public')->delete('tmp/'.$file_name);
+            Storage::disk('public')->delete("tmp/".$file_name);
         }
-
         $build->update(request()->only([
             'version',
             'status',
@@ -150,10 +122,8 @@ class ModpackBuildsController extends Controller
             'required_memory',
             'forge_version',
         ]));
-
         return redirect("/modpacks/$modpackSlug/{$build->version}");
     }
-
     /**
      * Remove build from application.
      *
@@ -166,13 +136,10 @@ class ModpackBuildsController extends Controller
     {
         $modpack = Modpack::where('slug', $modpackSlug)->firstOrFail();
         $this->authorize('update', $modpack);
-
         $build = Build::where('version', $buildVersion)
             ->where('modpack_id', $modpack->id)
             ->firstOrFail();
-
         $build->delete();
-
         return redirect("/modpacks/$modpackSlug");
     }
 }

--- a/app/Http/Controllers/ModpackBuildsController.php
+++ b/app/Http/Controllers/ModpackBuildsController.php
@@ -116,11 +116,9 @@ class ModpackBuildsController extends Controller
         ]);
 
         $file_name = request()->input('minecraft_version').'-'.request()->input('forge_version');
-<<<<<<< HEAD
+
         if (! Storage::exists("forge/".$file_name.".zip")){
-=======
-        if(! Storage::exists("forge/".$file_name.".zip")){
->>>>>>> 13358b6935f1a9e26eaff2dc28eadfd3e69d7480
+
             $forge_download = 'http://files.minecraftforge.net/maven/net/minecraftforge/forge/'.$file_name.'/forge-'.$file_name.'-universal.jar';
 
             $contents = file_get_contents($forge_download);
@@ -129,24 +127,18 @@ class ModpackBuildsController extends Controller
             Storage::disk('public')->put('/tmp/'.$file_name.'.jar', $contents);
             $tmp_file = 'tmp/'.$file_name.'.jar';
 
-<<<<<<< HEAD
-            if (! Storage::exists('forge')) {
-                Storage::makeDirectory('forge');
-=======
-            if (! Storage::exists("forge")) {
+<
                 Storage::makeDirectory("forge");
->>>>>>> 13358b6935f1a9e26eaff2dc28eadfd3e69d7480
+
             }
             $archive = new ZipArchive();
             $archive_path = storage_path('app/public/forge/');
 
             if ($archive->open($archive_path.$file_name.'.zip', ZipArchive::CREATE) === true) {
                 $archive->addFile(storage_path('/app/public/').$tmp_file, 'bin/modpack.jar');
-<<<<<<< HEAD
+
             }
-=======
-             }
->>>>>>> 13358b6935f1a9e26eaff2dc28eadfd3e69d7480
+
             $archive->close();
             Storage::disk('public')->delete('tmp/'.$file_name);
         }

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -19,8 +19,6 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 
-
-
 class PackageReleasesController extends Controller
 {
     /**
@@ -47,22 +45,22 @@ class PackageReleasesController extends Controller
         $file_info = pathinfo($file_name);
         $tmp_file = $request->file('file')->store('tmp');
         $package_name = "{$package->slug}-{$request->version}.zip";
-        if(! Storage::exists("modpack/{$package->slug}")) {
+        if (! Storage::exists("modpack/{$package->slug}")) {
             Storage::makeDirectory("modpack/{$package->slug}");
         }
-        if ($file_info['extension'] == 'zip'){
+        if ($file_info['extension'] == 'zip') {
             Storage::move($tmp_file, "modpack/{$package->slug}/".$package_name);
-        }else{
+        } else {
             $archive = new ZipArchive();
             $archive_path = storage_path("app/public/modpack/{$package->slug}");
-            if ($archive->open($archive_path."/".$package_name, ZipArchive::CREATE) === TRUE){
-                $archive->addFile(storage_path("app/public/".$tmp_file), request()->input('type')."/".$file_name);
+            if ($archive->open($archive_path.'/'.$package_name, ZipArchive::CREATE) === TRUE){
+                $archive->addFile(storage_path('app/public/'.$tmp_file), request()->input('type').'/'.$file_name);
             }
             $archive->close();
 
         }
         Storage::disk('public')->delete($tmp_file);
-        $hash_path = url('/')."/"."storage/"."{$package->slug}/".$package_name;
+        $hash_path = url('/').'/'."storage/'.'{$package->slug}/'.$package_name;
         Release::create([
             'package_id' => $package->id,
             'version' => $request->version,

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -18,6 +18,9 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 
+use ZipArchive;
+//use File;
+
 class PackageReleasesController extends Controller
 {
     /**
@@ -37,19 +40,40 @@ class PackageReleasesController extends Controller
 
         request()->validate([
             'version' => ['required', 'regex:/^[a-zA-Z0-9_-][.a-zA-Z0-9_-]*$/', Rule::unique('releases')->where('package_id', $package->id)],
-            'archive' => ['mimes:zip'],
+            'type' => ['required'],
+            'file' => ['required'],
         ]);
 
-        $archive = request()
-            ->file('archive')
-            ->storeAs($package->slug, "{$package->slug}-{$request->version}.zip");
+        $file_name = $_FILES['file']['name'];
+
+        $file = $request->file('file')->store('tmp');
+        $archive = new ZipArchive();
+        $archive_directory = "modpack/" . $package->slug;
+        $public = storage_path('app/public/');
+        $archive_name = $archive_directory . "/" . "{$package->slug}-{$request->version}.zip";
+        $hash_path = url('/') . "storage/" . "{$package->slug}-{$request->version}.zip";
+        $storage_path = "{$package->slug}" . "/" . "{$package->slug}-{$request->version}.zip";
+
+
+
+        if(!Storage::exists($archive_directory)) {
+            Storage::makeDirectory($archive_directory);
+        }
+
+        if($archive->open($public . "/" . $archive_name, ZipArchive::CREATE) === TRUE){
+            $archive->addFile(storage_path("app/public/" . $file), "mods/". $file_name);
+        }
+
+        $archive->close();
+
+        Storage::disk('public')->delete($file);
 
         Release::create([
             'package_id' => $package->id,
             'version' => $request->version,
-            'path' => $archive,
-            'md5' => FileHash::hash(Storage::url($archive)),
-            'filesize' => request()->file('archive')->getSize(),
+            'path' => $storage_path,
+            'md5' => FileHash::hash($hash_path),
+            'filesize' => request()->file('file')->getSize(),
         ]);
 
         return redirect("/library/$packageSlug");

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -53,7 +53,7 @@ class PackageReleasesController extends Controller
         } else {
             $archive = new ZipArchive();
             $archive_path = storage_path("app/public/modpack/{$package->slug}");
-            if ($archive->open($archive_path.'/'.$package_name, ZipArchive::CREATE) === TRUE){
+            if ($archive->open($archive_path.'/'.$package_name, ZipArchive::CREATE) === true){
                 $archive->addFile(storage_path('app/public/'.$tmp_file), request()->input('type').'/'.$file_name);
             }
             $archive->close();

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -41,37 +41,32 @@ class PackageReleasesController extends Controller
         request()->validate([
             'version' => ['required', 'regex:/^[a-zA-Z0-9_-][.a-zA-Z0-9_-]*$/', Rule::unique('releases')->where('package_id', $package->id)],
             'type' => ['required'],
-            'file' => ['required'],
+            'file' => ['required', 'min:1', 'mimes:zip,jar,cfg,json'],
         ]);
-
         $file_name = $_FILES['file']['name'];
-
-        $file = $request->file('file')->store('tmp');
-        $archive = new ZipArchive();
-        $archive_directory = "modpack/" . $package->slug;
-        $public = storage_path('app/public/');
-        $archive_name = $archive_directory . "/" . "{$package->slug}-{$request->version}.zip";
-        $hash_path = url('/') ."/" . "storage/" . "{$package->slug}/" . "{$package->slug}-{$request->version}.zip";
-        $storage_path = "{$package->slug}-{$request->version}.zip";
-
-
-
-        if(!Storage::exists($archive_directory)) {
-            Storage::makeDirectory($archive_directory);
+        $file_info = pathinfo($file_name);
+        $tmp_file = $request->file('file')->store('tmp');
+        $package_name = "{$package->slug}-{$request->version}.zip";
+        if(!Storage::exists("modpack/{$package->slug}")) {
+            Storage::makeDirectory("modpack/{$package->slug}");
         }
+        if($file_info['extension'] == 'zip'){
+            Storage::move($tmp_file, "modpack/{$package->slug}/" . $package_name);
+        }else{
+            $archive = new ZipArchive();
+            $archive_path = storage_path("app/public/modpack/{$package->slug}");
+            if($archive->open($archive_path . "/" . $package_name, ZipArchive::CREATE) === TRUE){
+                $archive->addFile(storage_path("app/public/" . $tmp_file), request()->input('type') . "/". $file_name);
+            }
+            $archive->close();
 
-        if($archive->open($public . "/" . $archive_name, ZipArchive::CREATE) === TRUE){
-            $archive->addFile(storage_path("app/public/" . $file), request()->input('type') . "/". $file_name);
         }
-
-        $archive->close();
-
-        Storage::disk('public')->delete($file);
-
+        Storage::disk('public')->delete($tmp_file);
+        $hash_path = url('/') ."/" . "storage/" . "{$package->slug}/" . $package_name;
         Release::create([
             'package_id' => $package->id,
             'version' => $request->version,
-            'path' => $storage_path,
+            'path' => $package_name,
             'md5' => FileHash::hash($hash_path),
             'filesize' => request()->file('file')->getSize(),
         ]);

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -50,12 +50,12 @@ class PackageReleasesController extends Controller
         if(! Storage::exists("modpack/{$package->slug}")) {
             Storage::makeDirectory("modpack/{$package->slug}");
         }
-        if($file_info['extension'] == 'zip'){
+        if ($file_info['extension'] == 'zip'){
             Storage::move($tmp_file, "modpack/{$package->slug}/".$package_name);
         }else{
             $archive = new ZipArchive();
             $archive_path = storage_path("app/public/modpack/{$package->slug}");
-            if($archive->open($archive_path."/".$package_name, ZipArchive::CREATE) === TRUE){
+            if ($archive->open($archive_path."/".$package_name, ZipArchive::CREATE) === TRUE){
                 $archive->addFile(storage_path("app/public/".$tmp_file), request()->input('type')."/".$file_name);
             }
             $archive->close();

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -60,11 +60,9 @@ class PackageReleasesController extends Controller
 
         }
         Storage::disk('public')->delete($tmp_file);
-<<<<<<< HEAD
+
         $hash_path = url('/').'/'.'storage/'.'{$package->slug}/'.$package_name;
-=======
-        $hash_path = url('/').'/'."storage/'.'{$package->slug}/'.$package_name;
->>>>>>> 13358b6935f1a9e26eaff2dc28eadfd3e69d7480
+
         Release::create([
             'package_id' => $package->id,
             'version' => $request->version,

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -19,8 +19,6 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 
-
-
 class PackageReleasesController extends Controller
 {
     /**
@@ -47,22 +45,22 @@ class PackageReleasesController extends Controller
         $file_info = pathinfo($file_name);
         $tmp_file = $request->file('file')->store('tmp');
         $package_name = "{$package->slug}-{$request->version}.zip";
-        if(! Storage::exists("modpack/{$package->slug}")) {
+        if (! Storage::exists("modpack/{$package->slug}")) {
             Storage::makeDirectory("modpack/{$package->slug}");
         }
-        if ($file_info['extension'] == 'zip'){
+        if ($file_info['extension'] == 'zip') {
             Storage::move($tmp_file, "modpack/{$package->slug}/".$package_name);
-        }else{
+        } else {
             $archive = new ZipArchive();
             $archive_path = storage_path("app/public/modpack/{$package->slug}");
-            if ($archive->open($archive_path."/".$package_name, ZipArchive::CREATE) === TRUE){
-                $archive->addFile(storage_path("app/public/".$tmp_file), request()->input('type')."/".$file_name);
+            if ($archive->open($archive_path.'/'.$package_name, ZipArchive::CREATE) === TRUE){
+                $archive->addFile(storage_path('app/public/'.$tmp_file), request()->input('type').'/'.$file_name);
             }
             $archive->close();
 
         }
         Storage::disk('public')->delete($tmp_file);
-        $hash_path = url('/')."/"."storage/"."{$package->slug}/".$package_name;
+        $hash_path = url('/').'/'.'storage/'.'{$package->slug}/'.$package_name;
         Release::create([
             'package_id' => $package->id,
             'version' => $request->version,

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -61,7 +61,7 @@ class PackageReleasesController extends Controller
         }
         Storage::disk('public')->delete($tmp_file);
 
-        $hash_path = url('/').'/'.'storage/'.'{$package->slug}/'.$package_name;
+        $hash_path = url('/').'/'.'storage/'."{$package->slug}/".$package_name;
 
         Release::create([
             'package_id' => $package->id,

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -52,7 +52,7 @@ class PackageReleasesController extends Controller
         $public = storage_path('app/public/');
         $archive_name = $archive_directory . "/" . "{$package->slug}-{$request->version}.zip";
         $hash_path = url('/') . "storage/" . "{$package->slug}-{$request->version}.zip";
-        $storage_path = "{$package->slug}" . "/" . "{$package->slug}-{$request->version}.zip";
+        $storage_path = "{$package->slug}-{$request->version}.zip";
 
 
 
@@ -61,7 +61,7 @@ class PackageReleasesController extends Controller
         }
 
         if($archive->open($public . "/" . $archive_name, ZipArchive::CREATE) === TRUE){
-            $archive->addFile(storage_path("app/public/" . $file), "mods/". $file_name);
+            $archive->addFile(storage_path("app/public/" . $file), request()->input('type') . "/". $file_name);
         }
 
         $archive->close();

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -11,6 +11,7 @@
 
 namespace App\Http\Controllers;
 
+use ZipArchive;
 use App\Package;
 use App\Release;
 use App\Facades\FileHash;
@@ -18,7 +19,7 @@ use Illuminate\Http\Request;
 use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 
-use ZipArchive;
+
 
 class PackageReleasesController extends Controller
 {
@@ -46,22 +47,22 @@ class PackageReleasesController extends Controller
         $file_info = pathinfo($file_name);
         $tmp_file = $request->file('file')->store('tmp');
         $package_name = "{$package->slug}-{$request->version}.zip";
-        if(!Storage::exists("modpack/{$package->slug}")) {
+        if(! Storage::exists("modpack/{$package->slug}")) {
             Storage::makeDirectory("modpack/{$package->slug}");
         }
         if($file_info['extension'] == 'zip'){
-            Storage::move($tmp_file, "modpack/{$package->slug}/" . $package_name);
+            Storage::move($tmp_file, "modpack/{$package->slug}/".$package_name);
         }else{
             $archive = new ZipArchive();
             $archive_path = storage_path("app/public/modpack/{$package->slug}");
-            if($archive->open($archive_path . "/" . $package_name, ZipArchive::CREATE) === TRUE){
-                $archive->addFile(storage_path("app/public/" . $tmp_file), request()->input('type') . "/". $file_name);
+            if($archive->open($archive_path."/".$package_name, ZipArchive::CREATE) === TRUE){
+                $archive->addFile(storage_path("app/public/".$tmp_file), request()->input('type')."/".$file_name);
             }
             $archive->close();
 
         }
         Storage::disk('public')->delete($tmp_file);
-        $hash_path = url('/') ."/" . "storage/" . "{$package->slug}/" . $package_name;
+        $hash_path = url('/')."/"."storage/"."{$package->slug}/".$package_name;
         Release::create([
             'package_id' => $package->id,
             'version' => $request->version,

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -19,7 +19,6 @@ use Illuminate\Validation\Rule;
 use Illuminate\Support\Facades\Storage;
 
 use ZipArchive;
-//use File;
 
 class PackageReleasesController extends Controller
 {

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -53,7 +53,7 @@ class PackageReleasesController extends Controller
         } else {
             $archive = new ZipArchive();
             $archive_path = storage_path("app/public/modpack/{$package->slug}");
-            if ($archive->open($archive_path.'/'.$package_name, ZipArchive::CREATE) === true){
+            if ($archive->open($archive_path.'/'.$package_name, ZipArchive::CREATE) === true) {
                 $archive->addFile(storage_path('app/public/'.$tmp_file), request()->input('type').'/'.$file_name);
             }
             $archive->close();

--- a/app/Http/Controllers/PackageReleasesController.php
+++ b/app/Http/Controllers/PackageReleasesController.php
@@ -51,7 +51,7 @@ class PackageReleasesController extends Controller
         $archive_directory = "modpack/" . $package->slug;
         $public = storage_path('app/public/');
         $archive_name = $archive_directory . "/" . "{$package->slug}-{$request->version}.zip";
-        $hash_path = url('/') . "storage/" . "{$package->slug}-{$request->version}.zip";
+        $hash_path = url('/') ."/" . "storage/" . "{$package->slug}/" . "{$package->slug}-{$request->version}.zip";
         $storage_path = "{$package->slug}-{$request->version}.zip";
 
 

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -14,7 +14,6 @@ namespace App\Http\Controllers;
 use App\Package;
 use App\Release;
 use Illuminate\Validation\Rule;
-
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 
@@ -92,9 +91,9 @@ class PackagesController extends Controller
            'slug' => ['sometimes', 'required', 'alpha_dash', Rule::unique('packages')->ignore($package->id)],
         ]);
 
-        $files = Storage::allFiles('modpack/'. $package->slug);
+        $files = Storage::allFiles('modpack/'.$package->slug);
 
-        foreach ($files as $file){
+        foreach ($files as $file) {
             $file = str_replace('modpack/'.$package->slug, '', $file);
             $newFileName = str_replace($package->slug, request()->input('slug'), $file);
             Storage::move('modpack/'.$package->slug.$file, 'modpack/'.$package->slug.$newFileName);
@@ -105,7 +104,7 @@ class PackagesController extends Controller
 
         }
 
-        File::moveDirectory(storage_path('app/public/modpack/'.$package->slug), storage_path('app/public/modpack/'. request()->input('slug')));
+        File::moveDirectory(storage_path('app/public/modpack/'.$package->slug), storage_path('app/public/modpack/'.request()->input('slug')));
 
         $package->update(request()->only([
             'name',

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -97,7 +97,7 @@ class PackagesController extends Controller
         foreach($files as $file){
             $file = str_replace('modpack/' . $package->slug, '', $file);
             $newFileName = str_replace($package->slug, request()->input('slug'), $file);
-            Storage::move('modpack/' . $package->slug . $file, 'modpack/' . $package->slug . $newFileName);
+            Storage::move('modpack/'.$package->slug.$file, 'modpack/'.$package->slug.$newFileName);
 
             Release::where('path', str_replace('/' , '', $file))->update([
                 'path' => str_replace('/' , '', $newFileName)
@@ -108,7 +108,7 @@ class PackagesController extends Controller
 
 
 
-        File::moveDirectory(storage_path('app/public/modpack/'. $package->slug), storage_path('app/public/modpack/'. request()->input('slug')));
+        File::moveDirectory(storage_path('app/public/modpack/'.$package->slug), storage_path('app/public/modpack/'. request()->input('slug')));
 
 
 
@@ -136,7 +136,7 @@ class PackagesController extends Controller
 
         $package->delete();
 
-        Storage::disk('public')->deleteDirectory("modpack/" . $package->slug, true);
+        Storage::disk('public')->deleteDirectory("modpack/".$package->slug, true);
 
         return redirect('library');
     }

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -14,6 +14,8 @@ namespace App\Http\Controllers;
 use App\Package;
 use Illuminate\Validation\Rule;
 
+use Illuminate\Support\Facades\File;
+
 class PackagesController extends Controller
 {
     /**
@@ -88,6 +90,8 @@ class PackagesController extends Controller
            'slug' => ['sometimes', 'required', 'alpha_dash', Rule::unique('packages')->ignore($package->id)],
         ]);
 
+        File::moveDirectory(storage_path('app/public/modpack/'. $package->slug), storage_path('app/public/modpack/'. request()->input('slug')));
+
         $package->update(request()->only([
             'name',
             'slug',
@@ -96,6 +100,8 @@ class PackagesController extends Controller
             'donation_url',
             'description',
         ]));
+
+
 
         return redirect('library/'.$package->slug);
     }

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -94,23 +94,18 @@ class PackagesController extends Controller
 
         $files = Storage::allFiles('modpack/'. $package->slug);
 
-        foreach($files as $file){
-            $file = str_replace('modpack/' . $package->slug, '', $file);
+        foreach ($files as $file){
+            $file = str_replace('modpack/'.$package->slug, '', $file);
             $newFileName = str_replace($package->slug, request()->input('slug'), $file);
             Storage::move('modpack/'.$package->slug.$file, 'modpack/'.$package->slug.$newFileName);
 
-            Release::where('path', str_replace('/' , '', $file))->update([
-                'path' => str_replace('/' , '', $newFileName)
+            Release::where('path', str_replace('/', '', $file))->update([
+                'path' => str_replace('/', '', $newFileName),
             ]);
 
         }
 
-
-
-
         File::moveDirectory(storage_path('app/public/modpack/'.$package->slug), storage_path('app/public/modpack/'. request()->input('slug')));
-
-
 
         $package->update(request()->only([
             'name',
@@ -120,10 +115,6 @@ class PackagesController extends Controller
             'donation_url',
             'description',
         ]));
-
-
-
-
 
         return redirect('library/'.$package->slug);
     }
@@ -136,7 +127,7 @@ class PackagesController extends Controller
 
         $package->delete();
 
-        Storage::disk('public')->deleteDirectory("modpack/".$package->slug, true);
+        Storage::disk('public')->deleteDirectory('modpack/'.$package->slug, true);
 
         return redirect('library');
     }

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -14,7 +14,6 @@ namespace App\Http\Controllers;
 use App\Package;
 use App\Release;
 use Illuminate\Validation\Rule;
-
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Storage;
 
@@ -92,9 +91,9 @@ class PackagesController extends Controller
            'slug' => ['sometimes', 'required', 'alpha_dash', Rule::unique('packages')->ignore($package->id)],
         ]);
 
-        $files = Storage::allFiles('modpack/'. $package->slug);
+        $files = Storage::allFiles('modpack/'.$package->slug);
 
-        foreach ($files as $file){
+        foreach ($files as $file) {
             $file = str_replace('modpack/'.$package->slug, '', $file);
             $newFileName = str_replace($package->slug, request()->input('slug'), $file);
             Storage::move('modpack/'.$package->slug.$file, 'modpack/'.$package->slug.$newFileName);
@@ -102,10 +101,9 @@ class PackagesController extends Controller
             Release::where('path', str_replace('/', '', $file))->update([
                 'path' => str_replace('/', '', $newFileName),
             ]);
-
         }
 
-        File::moveDirectory(storage_path('app/public/modpack/'.$package->slug), storage_path('app/public/modpack/'. request()->input('slug')));
+        File::moveDirectory(storage_path('app/public/modpack/'.$package->slug), storage_path('app/public/modpack/'.request()->input('slug')));
 
         $package->update(request()->only([
             'name',

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -12,9 +12,11 @@
 namespace App\Http\Controllers;
 
 use App\Package;
+use App\Release;
 use Illuminate\Validation\Rule;
 
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Storage;
 
 class PackagesController extends Controller
 {
@@ -90,7 +92,25 @@ class PackagesController extends Controller
            'slug' => ['sometimes', 'required', 'alpha_dash', Rule::unique('packages')->ignore($package->id)],
         ]);
 
+        $files = Storage::allFiles('modpack/'. $package->slug);
+
+        foreach($files as $file){
+            $file = str_replace('modpack/' . $package->slug, '', $file);
+            $newFileName = str_replace($package->slug, request()->input('slug'), $file);
+            Storage::move('modpack/' . $package->slug . $file, 'modpack/' . $package->slug . $newFileName);
+
+            Release::where('path', str_replace('/' , '', $file))->update([
+                'path' => str_replace('/' , '', $newFileName)
+            ]);
+
+        }
+
+
+
+
         File::moveDirectory(storage_path('app/public/modpack/'. $package->slug), storage_path('app/public/modpack/'. request()->input('slug')));
+
+
 
         $package->update(request()->only([
             'name',
@@ -100,6 +120,8 @@ class PackagesController extends Controller
             'donation_url',
             'description',
         ]));
+
+
 
 
 
@@ -113,6 +135,8 @@ class PackagesController extends Controller
         $this->authorize('delete', $package);
 
         $package->delete();
+
+        Storage::disk('public')->deleteDirectory("modpack/" . $package->slug, true);
 
         return redirect('library');
     }

--- a/app/Http/Controllers/ReleasesController.php
+++ b/app/Http/Controllers/ReleasesController.php
@@ -13,6 +13,8 @@ namespace App\Http\Controllers;
 
 use App\Release;
 
+use Illuminate\Support\Facades\Storage;
+
 class ReleasesController extends Controller
 {
     /**
@@ -26,9 +28,12 @@ class ReleasesController extends Controller
     {
         $release = Release::findOrFail($releaseId);
 
+
         $this->authorize('delete', $release);
 
         $release->delete();
+
+        Storage::disk('public')->delete("modpack/" . $release->package->slug . "/" .  $release->path);
 
         return response(null, 204);
     }

--- a/app/Http/Controllers/ReleasesController.php
+++ b/app/Http/Controllers/ReleasesController.php
@@ -33,7 +33,7 @@ class ReleasesController extends Controller
 
         $release->delete();
 
-        Storage::disk('public')->delete("modpack/" . $release->package->slug . "/" .  $release->path);
+        Storage::disk('public')->delete("modpack/".$release->package->slug."/".$release->path);
 
         return response(null, 204);
     }

--- a/app/Http/Controllers/ReleasesController.php
+++ b/app/Http/Controllers/ReleasesController.php
@@ -33,7 +33,7 @@ class ReleasesController extends Controller
 
         $release->delete();
 
-        Storage::disk('public')->delete("modpack/".$release->package->slug."/".$release->path);
+        Storage::disk('public')->delete('modpack/'.$release->package->slug.'/'.$release->path);
 
         return response(null, 204);
     }

--- a/app/Http/Controllers/ReleasesController.php
+++ b/app/Http/Controllers/ReleasesController.php
@@ -12,7 +12,6 @@
 namespace App\Http\Controllers;
 
 use App\Release;
-
 use Illuminate\Support\Facades\Storage;
 
 class ReleasesController extends Controller
@@ -27,7 +26,6 @@ class ReleasesController extends Controller
     public function destroy($releaseId)
     {
         $release = Release::findOrFail($releaseId);
-
 
         $this->authorize('delete', $release);
 

--- a/app/Http/Controllers/ReleasesController.php
+++ b/app/Http/Controllers/ReleasesController.php
@@ -28,7 +28,6 @@ class ReleasesController extends Controller
     {
         $release = Release::findOrFail($releaseId);
 
-
         $this->authorize('delete', $release);
 
         $release->delete();

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -23,11 +23,7 @@ class StorageController extends Controller
     public function getForgeFile($file_name)
     {
         $path = storage_path('app/public/forge/'.$file_name);
-<<<<<<< HEAD
 
-=======
-        
->>>>>>> 13358b6935f1a9e26eaff2dc28eadfd3e69d7480
         return response()->download($path);
     }
 

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -16,19 +16,21 @@ class StorageController extends Controller
     public function getModFile($slug, $file_name)
     {
         $path = storage_path('app/public/modpack/'.$slug.'/'.$file_name);
+
         return response()->download($path);
     }
 
     public function getForgeFile($file_name)
     {
         $path = storage_path('app/public/forge/'.$file_name);
+
         return response()->download($path);
     }
 
     public function getModpackIconsFile($file_name)
     {
         $path = storage_path('app/public/modpack_icons/'.$file_name);
-        return response()->download($path);
 
+        return response()->download($path);
     }
 }

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -16,19 +16,21 @@ class StorageController extends Controller
     public function getModFile($slug, $file_name)
     {
         $path = storage_path('app/public/modpack/'.$slug.'/'.$file_name);
+
         return response()->download($path);
     }
 
     public function getForgeFile($file_name)
     {
         $path = storage_path('app/public/forge/'.$file_name);
+        
         return response()->download($path);
     }
 
     public function getModpackIconsFile($file_name)
     {
         $path = storage_path('app/public/modpack_icons/'.$file_name);
-        return response()->download($path);
 
+        return response()->download($path);
     }
 }

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -15,13 +15,20 @@ class StorageController extends Controller
 {
     public function getModFile($slug, $file_name)
     {
-        $path = storage_path("app/public/modpack/" . $slug . "/" . $file_name);
+        $path = storage_path("app/public/modpack/".$slug."/".$file_name);
         return response()->download($path);
     }
 
     public function getForgeFile($file_name)
     {
-        $path = storage_path("app/public/forge/" . $file_name);
+        $path = storage_path("app/public/forge/".$file_name);
         return response()->download($path);
+    }
+
+    public function getModpackIconsFile($file_name)
+    {
+        $path = storage_path("app/public/modpack_icons/".$file_name);
+        return response()->download($path);
+
     }
 }

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -13,9 +13,15 @@ namespace App\Http\Controllers;
 
 class StorageController extends Controller
 {
-    public function getFile($slug, $file_name)
+    public function getModFile($slug, $file_name)
     {
         $path = storage_path("app/public/modpack/" . $slug . "/" . $file_name);
+        return response()->download($path);
+    }
+
+    public function getForgeFile($file_name)
+    {
+        $path = storage_path("app/public/forge/" . $file_name);
         return response()->download($path);
     }
 }

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -11,9 +11,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Modpack;
-use App\Collaborator;
-
 class StorageController extends Controller
 {
     public function getFile($slug, $file_name)

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Http\Controllers;
+
+use App\Modpack;
+use App\Collaborator;
+
+class StorageController extends Controller
+{
+    public function getFile($slug, $file_name)
+    {
+        $path = storage_path("app/public/modpack/" . $slug . "/" . $file_name);
+        return response()->download($path);
+    }
+}

--- a/app/Http/Controllers/StorageController.php
+++ b/app/Http/Controllers/StorageController.php
@@ -15,19 +15,19 @@ class StorageController extends Controller
 {
     public function getModFile($slug, $file_name)
     {
-        $path = storage_path("app/public/modpack/".$slug."/".$file_name);
+        $path = storage_path('app/public/modpack/'.$slug.'/'.$file_name);
         return response()->download($path);
     }
 
     public function getForgeFile($file_name)
     {
-        $path = storage_path("app/public/forge/".$file_name);
+        $path = storage_path('app/public/forge/'.$file_name);
         return response()->download($path);
     }
 
     public function getModpackIconsFile($file_name)
     {
-        $path = storage_path("app/public/modpack_icons/".$file_name);
+        $path = storage_path('app/public/modpack_icons/'.$file_name);
         return response()->download($path);
 
     }

--- a/app/Release.php
+++ b/app/Release.php
@@ -69,7 +69,7 @@ class Release extends Model
      */
     public function getUrlAttribute()
     {
-        return Storage::url($this->package->slug."/".$this->path);
+        return Storage::url($this->package->slug.'/'.$this->path);
     }
 
     /**

--- a/app/Release.php
+++ b/app/Release.php
@@ -69,7 +69,7 @@ class Release extends Model
      */
     public function getUrlAttribute()
     {
-        return Storage::url($this->path);
+        return Storage::url($this->package->slug . "/" . $this->path);
     }
 
     /**

--- a/app/Release.php
+++ b/app/Release.php
@@ -69,7 +69,7 @@ class Release extends Model
      */
     public function getUrlAttribute()
     {
-        return Storage::url($this->package->slug . "/" . $this->path);
+        return Storage::url($this->package->slug."/".$this->path);
     }
 
     /**

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -1,3 +1,6 @@
+php_value upload_max_filesize 20M
+php_value post_max_size 20M
+
 <IfModule mod_rewrite.c>
     <IfModule mod_negotiation.c>
         Options -MultiViews

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -20,30 +20,31 @@ Vue.component('release-table', require('./components/ReleaseTable.vue'));
 Vue.component('build-table', require('./components/BuildTable.vue'));
 Vue.component('passport-personal-access-tokens', require('./components/PersonalAccessTokens.vue'));
 Vue.component('assistant', require('./components/Assistant'));
+Vue.component('update-build', require('./components/UpdateBuild.vue'));
 
 Vue.filter('prettyBytes', function (num) {
     // jacked from: https://github.com/sindresorhus/pretty-bytes
     if (typeof num !== 'number' || isNaN(num)) {
         return '';
     }
-    
+
     var exponent;
     var unit;
     var neg = num < 0;
     var units = ['B', 'kB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-    
+
     if (neg) {
         num = -num;
     }
-    
+
     if (num < 1) {
         return (neg ? '-' : '') + num + ' B';
     }
-    
+
     exponent = Math.min(Math.floor(Math.log(num) / Math.log(1000)), units.length - 1);
     num = (num / Math.pow(1000, exponent)).toFixed(2) * 1;
     unit = units[exponent];
-    
+
     return (neg ? '-' : '') + num + ' ' + unit;
 });
 

--- a/resources/assets/js/components/UpdateBuild.vue
+++ b/resources/assets/js/components/UpdateBuild.vue
@@ -1,0 +1,137 @@
+<template>
+    <div class="box">
+        <h1>Build Settings</h1>
+        <div class="box-body">
+
+            <form role="form" @submit.prevent="update">
+                <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">Minecraft Version</label>
+                    </div>
+                    <div class="field-body">
+                        <div class="field">
+                            <div class="control">
+
+                                <select class="input" name="minecraft_version" v-model="build.minecraft_version" v-on:change="fetchForgeVersons">
+                                    <option v-for="mcversion in mcversions" :selected="mcversion == build.minecraft_version">{{ mcversion }}</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">Forge Version</label>
+                    </div>
+                    <div class="field-body">
+                        <div class="field">
+                            <div class="control">
+                                <select class="input" name="minecraft_version" v-model="build.forge_version" v-on:change="fetchForgeVersons">
+                                    <option v-for="forgeversion in forgeversions" :selected="forgeversion == build.forge_version">{{ forgeversion }}</option>
+                                </select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">Java Version</label>
+                    </div>
+                    <div class="field-body">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" name="java_version" v-model="build.java_version" />
+
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">Required Memory</label>
+                    </div>
+                    <div class="field-body">
+                        <div class="field has-addons">
+                            <div class="control is-expanded">
+                                <input class="input" name="required_memory" v-model="build.required_memory" />
+
+                            </div>
+                            <div class="control">
+                                <p class="button is-static">MB</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <div class="field-label">
+                        &nbsp;
+                    </div>
+                    <div class="field-body">
+                        <div class="control">
+                            <button class="button" type="submit">Update</button>
+                        </div>
+                    </div>
+                </div>
+
+            </form>
+        </div>
+    </div>
+
+
+</template>
+
+<script>
+    export default{
+        props: ['build'],
+        data(){
+            return{
+                mcversions: [],
+                forgeversions: []
+            }
+        },
+        mounted() {
+            this.build = this.build;
+            this.fetchMCVersions();
+        },
+        methods: {
+            fetchMCVersions: function(){
+                axios.get('/forge')
+                .then((response) => {
+
+                    this.mcversions = response.data;
+                    this.fetchForgeVersons();
+                });
+
+            },
+            fetchForgeVersons: function(){
+                axios.get('/forge/' + this.build.minecraft_version)
+                .then((response) => {
+                    this.forgeversions = response.data;
+
+                });
+            },
+            update: function() {
+
+                var bodyFormData = new FormData();
+                bodyFormData.set('required_memory', this.build.required_memory);
+                bodyFormData.set('minecraft_version', this.build.minecraft_version);
+                bodyFormData.set('forge_version', this.build.forge_version);
+                bodyFormData.set('java_version', this.build.java_version);
+                console.log(this.build.minecraft_version);
+                axios.post('/modpacks/' + this.build.modpack.slug + '/' + this.build.version, bodyFormData, {
+                        config: { headers: {'Content-Type': 'multipart/form-data' }}
+                })
+                .then((response) => {
+
+                })
+                .catch((error) => {
+                    console.log(error);
+                });
+            }
+        }
+    }
+</script>

--- a/resources/assets/js/components/UpdateBuild.vue
+++ b/resources/assets/js/components/UpdateBuild.vue
@@ -4,6 +4,23 @@
         <div class="box-body">
 
             <form role="form" @submit.prevent="update">
+
+                <!-- Errors -->
+                <div class="field is-horizontal" v-if="messages.length > 0">
+                    <div class="field-label is-normal">
+                        &nbsp;
+                    </div>
+                    <div class="field-body">
+                        <div class="notification is-success">
+                            <ul>
+                                <li v-for="message in messages">
+                                    {{ message }}
+                                </li>
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="field is-horizontal">
                     <div class="field-label is-normal">
                         <label class="label">Minecraft Version</label>
@@ -11,7 +28,6 @@
                     <div class="field-body">
                         <div class="field">
                             <div class="control">
-
                                 <select class="input" name="minecraft_version" v-model="build.minecraft_version" v-on:change="fetchForgeVersons">
                                     <option v-for="mcversion in mcversions" :selected="mcversion == build.minecraft_version">{{ mcversion }}</option>
                                 </select>
@@ -90,7 +106,8 @@
         data(){
             return{
                 mcversions: [],
-                forgeversions: []
+                forgeversions: [],
+                messages : []
             }
         },
         mounted() {
@@ -121,12 +138,12 @@
                 bodyFormData.set('minecraft_version', this.build.minecraft_version);
                 bodyFormData.set('forge_version', this.build.forge_version);
                 bodyFormData.set('java_version', this.build.java_version);
-                
+
                 axios.post('/modpacks/' + this.build.modpack.slug + '/' + this.build.version, bodyFormData, {
                         config: { headers: {'Content-Type': 'multipart/form-data' }}
                 })
                 .then((response) => {
-
+                    this.messages = ['The build information has been updated!'];
                 })
                 .catch((error) => {
                     console.log(error);

--- a/resources/assets/js/components/UpdateBuild.vue
+++ b/resources/assets/js/components/UpdateBuild.vue
@@ -121,7 +121,7 @@
                 bodyFormData.set('minecraft_version', this.build.minecraft_version);
                 bodyFormData.set('forge_version', this.build.forge_version);
                 bodyFormData.set('java_version', this.build.java_version);
-                console.log(this.build.minecraft_version);
+                
                 axios.post('/modpacks/' + this.build.modpack.slug + '/' + this.build.version, bodyFormData, {
                         config: { headers: {'Content-Type': 'multipart/form-data' }}
                 })

--- a/resources/views/builds/show.blade.php
+++ b/resources/views/builds/show.blade.php
@@ -65,8 +65,9 @@
             <build-table :releases='{{ json_encode($build->releases) }}'></build-table>
         </div>
         @endif
-        
-        @include('builds.partials.update-build')
+
+        <!-- @include('builds.partials.update-build') -->
+        <update-build :build="{{ json_encode($build) }}"></update-build>
         @include('builds.partials.danger-zone')
     </section>
 @endsection

--- a/resources/views/modpacks/partials/danger-zone.blade.php
+++ b/resources/views/modpacks/partials/danger-zone.blade.php
@@ -14,7 +14,7 @@
                     </div>
                     <div class="level-right">
                         <div class="level-item">
-                            <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                            <form method="post" action="/modpacks/{{ $modpack->slug }}" onsubmit="return confirm('Are you sure you want to make this modpack public?');">
                                 {{ csrf_field() }}
                                 {{ method_field('patch') }}
 
@@ -37,7 +37,7 @@
                     </div>
                     <div class="level-right">
                         <div class="level-item">
-                            <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                            <form method="post" action="/modpacks/{{ $modpack->slug }}" onsubmit="return confirm('Are you sure you want to make this modpack private?');">
                                 {{ csrf_field() }}
                                 {{ method_field('patch') }}
 
@@ -59,7 +59,7 @@
                 </div>
                 <div class="level-right">
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                        <form method="post" action="/modpacks/{{ $modpack->slug }}" onsubmit="return confirm('Are you sure you want to change the modpack slug?');">
                             {{ csrf_field() }}
                             {{ method_field('patch') }}
 
@@ -91,7 +91,7 @@
                 </div>
                 <div class="level-right">
                     <div class="level-item">
-                        <form method="post" action="/modpacks/{{ $modpack->slug }}">
+                        <form method="post" action="/modpacks/{{ $modpack->slug }}" onsubmit="return confirm('Are you sure you want to delete this?');">
                             {{ csrf_field() }}
                             {{ method_field('delete') }}
                             <button class="button is-danger is-outlined" type="submit">Delete this modpack</button>

--- a/resources/views/packages/partials/create-release.blade.php
+++ b/resources/views/packages/partials/create-release.blade.php
@@ -23,6 +23,31 @@
                 </div>
             </div>
 
+            <div class="field is-horizontal">
+                <div class="field-label is-normal">
+                    <label class="label">Type</label>
+                </div>
+                <div class="field-body">
+                    <div class="field">
+                        <div class="control has-icons-left is-expanded">
+
+                            <select name="type" id="type" class="input {{ $errors->has('type') ? 'is-danger' : '' }}">
+                                <option value="mod">Mod</option>
+                                <option value="config">Config</option>
+                                <option value="forge">Forge</option>
+                                <option value="other">Other</option>
+                            </select>
+                            <span class="icon is-small is-left">
+                                <i class="fa fa-code-fork"></i>
+                            </span>
+                            @if($errors->has('version'))
+                                <p class="help is-danger">{{ $errors->first('version') }}</p>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+            </div>
+
 
             <div class="field is-horizontal">
                 <div class="field-label is-normal">
@@ -33,9 +58,9 @@
                         <div class="control">
                             <div class="columns">
                                 <div class="column is-narrow">
-                                    <div class="file {{ $errors->has('archive') ? 'is-danger' : '' }}">
+                                    <div class="file {{ $errors->has('file') ? 'is-danger' : '' }}">
                                         <label class="file-label">
-                                            <input class="file-input" type="file" name="archive">
+                                            <input class="file-input" type="file" name="file">
                                             <span class="file-cta">
                                                         <span class="file-icon">
                                                             <i class="fa fa-upload"></i>
@@ -48,8 +73,8 @@
                                     </div>
                                 </div>
                                 <div class="column is-flex" style="align-items: center;">
-                                    @if($errors->has('archive'))
-                                        <p class="is-size-7 has-text-danger">{{ $errors->first('archive') }}</p>
+                                    @if($errors->has('file'))
+                                        <p class="is-size-7 has-text-danger">{{ $errors->first('file') }}</p>
                                     @endif
                                 </div>
                             </div>

--- a/resources/views/packages/partials/create-release.blade.php
+++ b/resources/views/packages/partials/create-release.blade.php
@@ -32,10 +32,8 @@
                         <div class="control has-icons-left is-expanded">
 
                             <select name="type" id="type" class="input {{ $errors->has('type') ? 'is-danger' : '' }}">
-                                <option value="mod">Mod</option>
+                                <option value="mods">Mod</option>
                                 <option value="config">Config</option>
-                                <option value="forge">Forge</option>
-                                <option value="other">Other</option>
                             </select>
                             <span class="icon is-small is-left">
                                 <i class="fa fa-code-fork"></i>

--- a/resources/views/packages/show.blade.php
+++ b/resources/views/packages/show.blade.php
@@ -21,7 +21,7 @@
         @can('create', App\Release::class)
             @include('packages.partials.create-release')
         @endcan
-
+        
         @if(count($package->releases))
             <release-table :releases='{{ json_encode($package->releases) }}'></release-table>
         @endif

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,7 @@ Route::view('/login', 'auth.login')->name('auth.show-login');
 Route::post('/login', 'Auth\LoginController@login')->name('auth.login');
 Route::post('/logout', 'Auth\LoginController@logout')->name('auth.logout');
 
-
+Route::get('/storage/modpack_icons/{file_name}', 'StorageController@getModpackIconsFile');
 Route::get('/storage/forge/{file_name}', 'StorageController@getForgeFile');
 Route::get('/storage/{slug}/{file_name}', 'StorageController@getModFile');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -73,18 +73,3 @@ Route::middleware('auth')->namespace('Admin')->prefix('settings')->group(functio
     Route::post('users/{user}', 'UsersController@update');
     Route::delete('users/{user}', 'UsersController@destroy');
 });
-
-Route::get('/testing', function(){
-    $xml = simplexml_load_file("http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml");
-    $json = json_decode(json_encode($xml));
-
-
-    $versions  = $json->versioning->versions->version;
-    $version_list = array();
-    foreach($versions as $version){
-        $explode = explode('-', $version, 2);
-        $version_list[$explode[0]][] = $explode[1];
-    }
-
-
-});

--- a/routes/web.php
+++ b/routes/web.php
@@ -44,6 +44,9 @@ Route::middleware('auth')->group(function () {
 
     Route::delete('/bundles', 'BundlesController@destroy');
     Route::post('/bundles', 'BundlesController@store');
+
+    Route::get('/forge', 'ForgeController@getMCVersions');
+    Route::get('/forge/{mcversion}', 'ForgeController@getForgeVersions');
 });
 
 Route::middleware('auth')->namespace('Admin')->prefix('settings')->group(function () {
@@ -66,4 +69,19 @@ Route::middleware('auth')->namespace('Admin')->prefix('settings')->group(functio
     Route::post('users', 'UsersController@store');
     Route::post('users/{user}', 'UsersController@update');
     Route::delete('users/{user}', 'UsersController@destroy');
+});
+
+Route::get('/testing', function(){
+    $xml = simplexml_load_file("http://files.minecraftforge.net/maven/net/minecraftforge/forge/maven-metadata.xml");
+    $json = json_decode(json_encode($xml));
+
+
+    $versions  = $json->versioning->versions->version;
+    $version_list = array();
+    foreach($versions as $version){
+        $explode = explode('-', $version, 2);
+        $version_list[$explode[0]][] = $explode[1];
+    }
+
+
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -17,7 +17,6 @@ Route::get('/storage/modpack_icons/{file_name}', 'StorageController@getModpackIc
 Route::get('/storage/forge/{file_name}', 'StorageController@getForgeFile');
 Route::get('/storage/{slug}/{file_name}', 'StorageController@getModFile');
 
-
 Route::middleware('auth')->group(function () {
     Route::get('/', 'DashboardController');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,6 +13,8 @@ Route::view('/login', 'auth.login')->name('auth.show-login');
 Route::post('/login', 'Auth\LoginController@login')->name('auth.login');
 Route::post('/logout', 'Auth\LoginController@logout')->name('auth.logout');
 
+Route::get('/storage/{slug}/{file_name}', 'StorageController@getFile');
+
 Route::middleware('auth')->group(function () {
     Route::get('/', 'DashboardController');
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -13,7 +13,10 @@ Route::view('/login', 'auth.login')->name('auth.show-login');
 Route::post('/login', 'Auth\LoginController@login')->name('auth.login');
 Route::post('/logout', 'Auth\LoginController@logout')->name('auth.logout');
 
-Route::get('/storage/{slug}/{file_name}', 'StorageController@getFile');
+
+Route::get('/storage/forge/{file_name}', 'StorageController@getForgeFile');
+Route::get('/storage/{slug}/{file_name}', 'StorageController@getModFile');
+
 
 Route::middleware('auth')->group(function () {
     Route::get('/', 'DashboardController');


### PR DESCRIPTION
- Added Upload Mod Files/Config (as individual file or zip file) Files to storage.
- Added delete of the uploaded mod files when a package has been deleted
- Added delete of the all packages if a full package is deleted
- Added Forge "Caching" All you need to do is select the minecraft version and the forge version hit update and the system does the rest for you. If the "cached" file exists it will not re-download from the forge website
- Added renaming of mod/config storage files if the package slug gets changed. 
- Added storage routes to give a public facing link for mod downloading.