### PR TITLE
Add teams

### DIFF
--- a/app/Http/Controllers/ModpacksController.php
+++ b/app/Http/Controllers/ModpacksController.php
@@ -60,6 +60,7 @@ class ModpacksController extends Controller
             'slug' => request('slug'),
             'status' => request('status'),
             'icon_path' => request('modpack_icon', new NullFile)->store('modpack_icons'),
+            'team_id' => request()->user()->currentTeam->id,
         ]);
 
         $modpack->addCollaborator(auth()->user()->id);

--- a/app/Http/Controllers/PackagesController.php
+++ b/app/Http/Controllers/PackagesController.php
@@ -65,14 +65,15 @@ class PackagesController extends Controller
             'donation_url' => ['nullable', 'url'],
         ]);
 
-        $package = Package::create(request()->only([
-            'name',
-            'slug',
-            'author',
-            'website_url',
-            'donation_url',
-            'description',
-        ]));
+        $package = Package::create([
+            'name' => request('name'),
+            'slug' => request('slug'),
+            'author' => request('author'),
+            'website_url' => request('website_url'),
+            'donation_url' => request('donation_url'),
+            'description' => request('description'),
+            'team_id' => request()->user()->currentTeam->id,
+        ]);
 
         return redirect('library/'.$package->slug);
     }

--- a/app/Http/Controllers/Settings/TeamNameController.php
+++ b/app/Http/Controllers/Settings/TeamNameController.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Http\Controllers\Settings;
+
+use App\Team;
+use App\Http\Controllers\Controller;
+
+class TeamNameController extends Controller
+{
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \App\Team  $team
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Team $team)
+    {
+        $this->validate(request(), [
+            'name' => ['required'],
+        ]);
+
+        $team->update([
+            'name' => request('name'),
+        ]);
+
+        return response()->json(['data' => $team]);
+    }
+}

--- a/app/Http/Controllers/Settings/TeamsController.php
+++ b/app/Http/Controllers/Settings/TeamsController.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App\Http\Controllers\Settings;
+
+use App\Team;
+use App\Http\Controllers\Controller;
+
+class TeamsController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        return response()->json(['data' => Team::all()]);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function store()
+    {
+        $this->validate(request(), [
+            'name' => ['required'],
+            'slug' => ['required', 'unique:teams'],
+        ]);
+
+        $team = Team::create([
+            'name' => request('name'),
+            'slug' => request('slug'),
+        ]);
+
+        return response()->json(['data' => $team], 201);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Team $team
+     * @return \Illuminate\Http\Response
+     * @throws \Exception
+     */
+    public function destroy(Team $team)
+    {
+        $team->delete();
+
+        return response(null, 204);
+    }
+}

--- a/app/Team.php
+++ b/app/Team.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Team extends Model
+{
+    protected $guarded = [];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class);
+    }
+
+    public function modpacks()
+    {
+        return $this->hasMany(Modpack::class);
+    }
+
+    public function packages()
+    {
+        return $this->hasMany(Package::class);
+    }
+}

--- a/app/User.php
+++ b/app/User.php
@@ -58,8 +58,35 @@ class User extends Authenticatable
             ->withTimestamps();
     }
 
+    public function teams()
+    {
+        return $this->belongsToMany(Team::class);
+    }
+
     public function grantRole($role)
     {
         $this->roles()->attach(Role::where('tag', $role)->first());
+    }
+
+    public function switchToTeam($team)
+    {
+        $this->current_team_id = $team->id;
+        $this->save();
+    }
+
+    public function currentTeam()
+    {
+        if (is_null($this->current_team_id)) {
+            $this->switchToTeam($this->teams->first());
+
+            return $this->currentTeam();
+        }
+
+        return $this->teams->find($this->current_team_id);
+    }
+
+    public function getCurrentTeamAttribute()
+    {
+        return $this->currentTeam();
     }
 }

--- a/database/factories/ModpackFactory.php
+++ b/database/factories/ModpackFactory.php
@@ -16,6 +16,9 @@ $factory->define(App\Modpack::class, function (Faker $faker) {
         'name' => $faker->sentence(3, true),
         'slug' => $faker->slug(3, true),
         'status' => 'public',
+        'team_id' => function () {
+            return factory(\App\Team::class)->create()->id;
+        },
     ];
 });
 

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -11,12 +11,9 @@
 
 use Faker\Generator as Faker;
 
-$factory->define(App\Package::class, function (Faker $faker) {
+$factory->define(App\Team::class, function (Faker $faker) {
     return [
-        'name' => 'Example Package',
-        'slug' => $faker->slug(3, true),
-        'team_id' => function () {
-            return factory(\App\Team::class)->create()->id;
-        },
+        'name' => $faker->streetName,
+        'slug' => $faker->slug,
     ];
 });

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -12,12 +12,10 @@
 use Faker\Generator as Faker;
 
 $factory->define(App\User::class, function (Faker $faker) {
-    static $password;
-
     return [
         'username' => $faker->name,
         'email' => $faker->unique()->safeEmail,
-        'password' => $password ?: $password = bcrypt('secret'),
+        'password' => '$2y$10$TKh8H1.PfQx37YgCzwiKb.KjNyWgaHb9cbcoQgdIVFlYg7B77UdFm', // secret
         'remember_token' => str_random(10),
     ];
 });

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -24,6 +24,7 @@ class CreateUsersTable extends Migration
     {
         Schema::create('users', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedInteger('current_team_id')->nullable();
             $table->string('username');
             $table->string('email')->unique();
             $table->string('password');

--- a/database/migrations/2017_09_06_032546_create_packages_table.php
+++ b/database/migrations/2017_09_06_032546_create_packages_table.php
@@ -24,6 +24,7 @@ class CreatePackagesTable extends Migration
     {
         Schema::create('packages', function (Blueprint $table) {
             $table->increments('id');
+            $table->unsignedInteger('team_id');
             $table->string('name');
             $table->string('slug')->unique();
             $table->string('author')->nullable();

--- a/database/migrations/2018_04_02_054318_create_teams_table.php
+++ b/database/migrations/2018_04_02_054318_create_teams_table.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateModpacksTable extends Migration
+class CreateTeamsTable extends Migration
 {
     /**
      * Run the migrations.
@@ -22,15 +22,10 @@ class CreateModpacksTable extends Migration
      */
     public function up()
     {
-        Schema::create('modpacks', function (Blueprint $table) {
+        Schema::create('teams', function (Blueprint $table) {
             $table->increments('id');
-            $table->unsignedInteger('team_id');
-            $table->unsignedInteger('recommended_build_id')->nullable();
-            $table->unsignedInteger('latest_build_id')->nullable();
-            $table->string('name')->unique();
-            $table->string('slug')->unique();
-            $table->string('status');
-            $table->string('icon_path')->nullable();
+            $table->string('name');
+            $table->string('slug');
             $table->timestamps();
         });
     }
@@ -42,6 +37,6 @@ class CreateModpacksTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('modpacks');
+        Schema::dropIfExists('teams');
     }
 }

--- a/database/migrations/2018_04_02_054428_create_team_user_table.php
+++ b/database/migrations/2018_04_02_054428_create_team_user_table.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateModpacksTable extends Migration
+class CreateTeamUserTable extends Migration
 {
     /**
      * Run the migrations.
@@ -22,15 +22,10 @@ class CreateModpacksTable extends Migration
      */
     public function up()
     {
-        Schema::create('modpacks', function (Blueprint $table) {
+        Schema::create('team_user', function (Blueprint $table) {
             $table->increments('id');
             $table->unsignedInteger('team_id');
-            $table->unsignedInteger('recommended_build_id')->nullable();
-            $table->unsignedInteger('latest_build_id')->nullable();
-            $table->string('name')->unique();
-            $table->string('slug')->unique();
-            $table->string('status');
-            $table->string('icon_path')->nullable();
+            $table->unsignedInteger('user_id');
             $table->timestamps();
         });
     }
@@ -42,6 +37,6 @@ class CreateModpacksTable extends Migration
      */
     public function down()
     {
-        Schema::dropIfExists('modpacks');
+        Schema::dropIfExists('team_user');
     }
 }

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -29,7 +29,8 @@ class DatabaseSeeder extends Seeder
         ]);
 
         $team = \App\Team::create([
-
+            'name' => 'Default Team',
+            'slug' => 'default',
         ]);
 
         $user->teams()->attach($team);

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -21,11 +21,18 @@ class DatabaseSeeder extends Seeder
     public function run()
     {
         // Create the default admin
-        \App\User::create([
+        $user = \App\User::create([
             'username' => 'Admin',
             'email' => 'admin@example.com',
             'password' => bcrypt('secret'),
             'is_admin' => true,
         ]);
+
+        $team = \App\Team::create([
+
+        ]);
+
+        $user->teams()->attach($team);
+        $user->switchToTeam($team);
     }
 }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -14,6 +14,7 @@ window.Vue = require('vue');
  */
 require('./forms/bootstrap');
 require('./filters/bootstrap');
+require('./components/settings/bootstrap');
 
 
 /**

--- a/resources/assets/js/components/settings/bootstrap.js
+++ b/resources/assets/js/components/settings/bootstrap.js
@@ -1,0 +1,3 @@
+require('./teams');
+require('./teams/create-team');
+require('./teams/list-teams');

--- a/resources/assets/js/components/settings/teams.js
+++ b/resources/assets/js/components/settings/teams.js
@@ -1,0 +1,41 @@
+Vue.component('team-settings', {
+    /**
+     * The component's data.
+     */
+    data() {
+        return {
+            teams: [],
+        };
+    },
+
+
+    /**
+     * Prepare the component.
+     */
+    mounted() {
+        this.getTeams();
+    },
+
+
+    /**
+     * The component has been created by Vue.
+     */
+    created() {
+        var self = this;
+
+        this.$on('updateTeams', function(){
+            self.getTeams();
+        });
+    },
+
+
+    methods: {
+        /**
+         * Get the teams.
+         */
+        getTeams() {
+            axios.get('/settings/teams')
+                .then(response => this.teams = response.data.data);
+        }
+    }
+});

--- a/resources/assets/js/components/settings/teams/create-team.js
+++ b/resources/assets/js/components/settings/teams/create-team.js
@@ -1,0 +1,57 @@
+Vue.component('create-team', {
+    props: [],
+
+
+    /**
+     * The component's data.
+     */
+    data() {
+        return {
+            form: new Form({
+                name: '',
+                slug: '',
+            })
+        };
+    },
+
+
+    watch: {
+        /**
+         * Watch the name for changes.
+         */
+        'form.name': function (val, oldVal) {
+            if (this.form.slug == '' || this.form.slug == oldVal.toLowerCase().replace(/[\s\W-]+/g, '-')) {
+                this.form.slug = val.toLowerCase().replace(/[\s\W-]+/g, '-');
+            }
+        }
+    },
+
+
+    methods: {
+        /**
+         * Create a new team.
+         */
+        createTeam() {
+            this.form.startProcessing();
+
+            axios.post('/settings/teams', this.form)
+                .then(() => {
+                    this.form.finishProcessing();
+                    this.resetForm();
+                    this.$parent.$emit('updateTeams');
+                })
+                .catch(errors => {
+                    this.form.setErrors(errors.response.data.errors);
+                });
+        },
+
+
+        /**
+         * Reset the form
+         */
+        resetForm() {
+            this.form.name = '';
+            this.form.slug = '';
+        }
+    }
+});

--- a/resources/assets/js/components/settings/teams/list-teams.js
+++ b/resources/assets/js/components/settings/teams/list-teams.js
@@ -1,0 +1,75 @@
+Vue.component('list-teams', {
+    props: ['teams'],
+
+
+    /**
+     * The component's data.
+     */
+    data() {
+        return {
+            deletingTeam: null,
+        }
+    },
+
+
+    methods: {
+        updateTeamName(team) {
+            swal({
+                text: 'Update team name.',
+                content: {
+                    element: "input",
+                    attributes: {
+                        value: team.name,
+                    },
+                },
+                button: {
+                    text: "Update",
+                    closeModal: false,
+                },
+            })
+            .then(name => {
+                axios.patch(`/settings/teams/${team.id}/name`, {name: name})
+                    .then(() => {
+                        this.$parent.$emit('updateTeams');
+                        swal.stopLoading();
+                        swal.close();
+                    })
+                    .catch(function (error) {
+                        swal("Oh noes!", error.response.data.message, "error");
+                    });
+            });
+        },
+
+
+        /**
+         * Get user confirmation that the client should be deleted.
+         */
+        approveTeamDelete(team) {
+            this.deletingTeam = team;
+
+            swal({
+                title: `Delete Team ${team.name}?`,
+                text: 'Are you sure you want to delete this team?',
+                icon: 'warning',
+                dangerMode: true,
+                buttons: [true, "Delete Team"],
+            })
+                .then((willDelete) => {
+                    if (willDelete) {
+                        this.deleteTeam();
+                    }
+                })
+        },
+
+
+        /**
+         * Delete the specified team.
+         */
+        deleteTeam() {
+            axios.delete(`/settings/teams/${this.deletingTeam.id}`)
+                .then(() => {
+                    this.$parent.$emit('updateTeams');
+                });
+        }
+    }
+});

--- a/resources/views/settings/clients.blade.php
+++ b/resources/views/settings/clients.blade.php
@@ -23,6 +23,14 @@
                         Solder Settings
                     </p>
                     <ul class="menu-list">
+                        <li>
+                            <a href="/settings/manage-teams">
+                                <span class="icon">
+                                    <i class="fa fa-fw fa-users"></i>
+                                </span>
+                                Teams
+                            </a>
+                        </li>
                         @can('keys.list')
                         <li>
                             <a href="/settings/keys">

--- a/resources/views/settings/keys.blade.php
+++ b/resources/views/settings/keys.blade.php
@@ -23,6 +23,14 @@
                         Solder Settings
                     </p>
                     <ul class="menu-list">
+                        <li>
+                            <a href="/settings/manage-teams">
+                                <span class="icon">
+                                    <i class="fa fa-fw fa-users"></i>
+                                </span>
+                                Teams
+                            </a>
+                        </li>
                         @can('keys.list')
                         <li>
                             <a href="/settings/keys" class="is-active">

--- a/resources/views/settings/permissions.blade.php
+++ b/resources/views/settings/permissions.blade.php
@@ -23,6 +23,14 @@
                         Solder Settings
                     </p>
                     <ul class="menu-list">
+                        <li>
+                            <a href="/settings/manage-teams">
+                                <span class="icon">
+                                    <i class="fa fa-fw fa-users"></i>
+                                </span>
+                                Teams
+                            </a>
+                        </li>
                         @can('keys.list')
                         <li>
                             <a href="/settings/keys">

--- a/resources/views/settings/teams.blade.php
+++ b/resources/views/settings/teams.blade.php
@@ -1,15 +1,17 @@
 @extends('layouts.app')
 
 @section('content')
+
     <section class="section">
         <div class="columns">
             <div class="column is-one-quarter">
-                <aside class="menu"><p class="menu-label">
+                <aside class="menu">
+                    <p class="menu-label">
                         Profile Settings
                     </p>
                     <ul class="menu-list">
                         <li>
-                            <a href="/settings/api" class="is-active">
+                            <a href="/settings/api">
                                 <span class="icon">
                                     <i class="fa fa-fw fa-user-circle-o"></i>
                                 </span>
@@ -22,36 +24,38 @@
                     </p>
                     <ul class="menu-list">
                         <li>
-                            <a href="/settings/manage-teams">
+                            <a href="/settings/manage-teams" class="is-active">
                                 <span class="icon">
                                     <i class="fa fa-fw fa-users"></i>
                                 </span>
                                 Teams
                             </a>
                         </li>
-                        @can('index', App\Key::class)
-                            <li>
-                                <a href="/settings/keys">
+                        @can('keys.list')
+                        <li>
+                            <a href="/settings/keys">
                                 <span class="icon">
                                     <i class="fa fa-fw fa-key"></i>
                                 </span>
-                                    Keys
-                                </a>
-                            </li>
+                                Keys
+                            </a>
+                        </li>
                         @endcan
+                        @can('clients.list')
                         <li>
                             <a href="/settings/clients">
-                            <span class="icon">
-                                <i class="fa fa-fw fa-window-maximize"></i>
-                            </span>
+                                <span class="icon">
+                                    <i class="fa fa-fw fa-window-maximize"></i>
+                                </span>
                                 Clients
                             </a>
                         </li>
+                        @endcan
                         <li>
                             <a href="/settings/users">
-                            <span class="icon">
-                                <i class="fa fa-fw fa-user-circle"></i>
-                            </span>
+                                <span class="icon">
+                                    <i class="fa fa-fw fa-user-circle"></i>
+                                </span>
                                 Users
                             </a>
                         </li>
@@ -65,12 +69,16 @@
                         </li>
                     </ul>
                 </aside>
-
             </div>
 
-            <div class="column">
-                <passport-personal-access-tokens></passport-personal-access-tokens>
-            </div>
+            <team-settings inline-template v-cloak>
+                <div class="column">
+
+                    @include('settings.teams.create-team')
+
+                    @include('settings.teams.list-teams')
+                </div>
+            </team-settings>
         </div>
     </section>
 @endsection

--- a/resources/views/settings/teams/create-team.blade.php
+++ b/resources/views/settings/teams/create-team.blade.php
@@ -1,0 +1,48 @@
+<create-team inline-template>
+    <div class="box">
+        <h1>Add Team</h1>
+        <div class="box-body">
+            <form @submit.prevent="createTeam()">
+
+                <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">Name</label>
+                    </div>
+                    <div class="field-body">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" :class="{'is-danger': form.errors.has('name')}" type="text" v-model="form.name">
+                                <p class="help is-danger" v-show="form.errors.has('name')">@{{ form.errors.get('name') }}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <div class="field-label is-normal">
+                        <label class="label">Slug</label>
+                    </div>
+                    <div class="field-body">
+                        <div class="field">
+                            <div class="control">
+                                <input class="input" :class="{'is-danger': form.errors.has('slug')}" type="text" v-model="form.slug">
+                                <p class="help is-danger" v-show="form.errors.has('slug')">@{{ form.errors.get('slug') }}</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="field is-horizontal">
+                    <div class="field-label">
+                        &nbsp;
+                    </div>
+                    <div class="field-body">
+                        <div class="control">
+                            <button class="button is-primary" type="submit">Add Team</button>
+                        </div>
+                    </div>
+                </div>
+            </form>
+        </div>
+    </div>
+</create-team>

--- a/resources/views/settings/teams/list-teams.blade.php
+++ b/resources/views/settings/teams/list-teams.blade.php
@@ -1,0 +1,41 @@
+<list-teams :teams="teams" inline-template>
+    <div class="box" v-if="teams.length">
+        <h1>Active Teams</h1>
+        <div class="box-body">
+            <ul class="list-group">
+
+                <li class="level list-group-item" v-for="team in teams">
+                    <div class="level-left">
+                        <div class="level-item" style="width:100px;">
+                        <span class="icon is-large">
+                            <i class="fa fa-users fa-2x"></i>
+                        </span>
+                        </div>
+                        <div class="level-item">
+                            <div class="content">
+                                <p>
+                                    <strong>@{{ team.name }}</strong><br>
+                                    <strong>slug:</strong> @{{ team.slug }}<br>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="level-right">
+                        <div class="level-item">
+                            <div class="field is-grouped">
+                                <p class="control">
+                                    <button class="button is-info is-outlined" @click="updateTeamName(team)">Edit</button>
+                                </p>
+                                <p class="control">
+                                    <button class="button is-danger is-outlined" @click="approveTeamDelete(team)">Delete</button>
+                                </p>
+                            </div>
+                        </div>
+                    </div>
+                </li>
+
+            </ul>
+        </div>
+    </div>
+</list-teams>

--- a/resources/views/settings/users.blade.php
+++ b/resources/views/settings/users.blade.php
@@ -23,6 +23,14 @@
                         Solder Settings
                     </p>
                     <ul class="menu-list">
+                        <li>
+                            <a href="/settings/manage-teams">
+                                <span class="icon">
+                                    <i class="fa fa-fw fa-users"></i>
+                                </span>
+                                Teams
+                            </a>
+                        </li>
                         @can('keys.list')
                         <li>
                             <a href="/settings/keys">

--- a/routes/web.php
+++ b/routes/web.php
@@ -65,4 +65,5 @@ Route::middleware('auth')->group(function () {
     Route::get('settings/teams', 'Settings\TeamsController@index');
     Route::post('settings/teams', 'Settings\TeamsController@store');
     Route::delete('settings/teams/{team}', 'Settings\TeamsController@destroy');
+    Route::patch('settings/teams/{team}/name', 'Settings\TeamNameController@update');
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -60,3 +60,9 @@ Route::middleware('auth')->namespace('Admin')->prefix('settings')->group(functio
     Route::post('users/{user}', 'UsersController@update');
     Route::delete('users/{user}', 'UsersController@destroy');
 });
+
+Route::middleware('auth')->group(function () {
+    Route::get('settings/teams', 'Settings\TeamsController@index');
+    Route::post('settings/teams', 'Settings\TeamsController@store');
+    Route::delete('settings/teams/{team}', 'Settings\TeamsController@destroy');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -54,6 +54,7 @@ Route::middleware('auth')->namespace('Admin')->prefix('settings')->group(functio
 
     Route::view('clients', 'settings.clients');
     Route::view('keys', 'settings.keys');
+    Route::view('manage-teams', 'settings.teams');
 
     Route::get('users', 'UsersController@index');
     Route::post('users', 'UsersController@store');

--- a/tests/Feature/AddModpackTest.php
+++ b/tests/Feature/AddModpackTest.php
@@ -11,6 +11,7 @@
 
 namespace Tests\Feature;
 
+use App\Team;
 use App\User;
 use App\Modpack;
 use Tests\TestCase;
@@ -26,6 +27,8 @@ class AddModpackTest extends TestCase
     public function an_admin_can_create_a_modpack()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->post('/modpacks', [
             'name' => 'Iron Tanks',
@@ -59,6 +62,8 @@ class AddModpackTest extends TestCase
     public function an_authorized_user_can_create_a_modpack()
     {
         $user = factory(User::class)->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         $user->grantRole('create-modpack');
 
         $response = $this->actingAs($user)
@@ -72,6 +77,8 @@ class AddModpackTest extends TestCase
     public function an_unauthorized_user_cannot_create_a_build()
     {
         $user = factory(User::class)->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->post('modpacks', $this->validParams());
@@ -84,6 +91,8 @@ class AddModpackTest extends TestCase
     public function name_is_required()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
             'name' => '',
@@ -98,6 +107,8 @@ class AddModpackTest extends TestCase
     public function slug_is_required()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
             'slug' => '',
@@ -112,6 +123,8 @@ class AddModpackTest extends TestCase
     public function slug_is_unique()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         factory(Modpack::class)->create(['slug' => 'existing-slug']);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
@@ -127,6 +140,8 @@ class AddModpackTest extends TestCase
     public function slug_is_url_safe()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
             'slug' => 'non url $safe slug',
@@ -141,6 +156,8 @@ class AddModpackTest extends TestCase
     public function status_is_required()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
             'status' => '',
@@ -155,6 +172,8 @@ class AddModpackTest extends TestCase
     public function status_is_valid()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
             'status' => 'invalid',
@@ -170,6 +189,8 @@ class AddModpackTest extends TestCase
     {
         Storage::fake();
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         $file = File::image('modpack-icon.png', 50, 50);
 
         $response = $this->actingAs($user)->post('/modpacks', $this->validParams([
@@ -191,6 +212,8 @@ class AddModpackTest extends TestCase
     {
         Storage::fake('s3');
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         $file = File::create('not-an-icon.pdf');
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
@@ -207,6 +230,8 @@ class AddModpackTest extends TestCase
     {
         Storage::fake('s3');
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         $file = File::image('modpack_icon.png', 49, 49);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
@@ -223,6 +248,8 @@ class AddModpackTest extends TestCase
     {
         Storage::fake('s3');
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         $file = File::image('poster.png', 100, 101);
 
         $response = $this->actingAs($user)->from('/dashboard')->post('/modpacks', $this->validParams([
@@ -238,6 +265,8 @@ class AddModpackTest extends TestCase
     public function modpack_icon_is_optional()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->post('/modpacks', $this->validParams([
             'modpack_icon' => null,
@@ -263,6 +292,8 @@ class AddModpackTest extends TestCase
     public function the_user_who_creates_a_modpack_is_also_a_contributor()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->post('/modpacks', [
             'name' => 'Iron Tanks',

--- a/tests/Feature/AddPackageTest.php
+++ b/tests/Feature/AddPackageTest.php
@@ -11,6 +11,7 @@
 
 namespace Tests\Feature;
 
+use App\Team;
 use App\User;
 use App\Package;
 use Tests\TestCase;
@@ -24,6 +25,8 @@ class AddPackageTest extends TestCase
     public function an_admin_can_create_a_package()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)->post('library', [
             'name' => 'Buildcraft',
@@ -59,6 +62,8 @@ class AddPackageTest extends TestCase
     public function an_authorized_user_can_create_a_package()
     {
         $user = factory(User::class)->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         $user->grantRole('create-package');
 
         $response = $this->actingAs($user)
@@ -72,6 +77,8 @@ class AddPackageTest extends TestCase
     public function an_unauthorized_user_cannot_create_a_package()
     {
         $user = factory(User::class)->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->post('library', $this->validParams());
@@ -84,6 +91,8 @@ class AddPackageTest extends TestCase
     public function name_is_required()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->from('library')
@@ -100,6 +109,8 @@ class AddPackageTest extends TestCase
     public function slug_is_required()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->from('library')
@@ -116,6 +127,8 @@ class AddPackageTest extends TestCase
     public function slug_is_unique()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
         factory(Package::class)->create(['slug' => 'buildcraft']);
 
         $response = $this->actingAs($user)
@@ -133,6 +146,8 @@ class AddPackageTest extends TestCase
     public function author_is_optional()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->from('library')
@@ -149,6 +164,8 @@ class AddPackageTest extends TestCase
     public function website_url_is_a_valid_url()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->from('library')
@@ -165,6 +182,8 @@ class AddPackageTest extends TestCase
     public function donation_url_is_a_valid_url()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->from('library')
@@ -181,6 +200,8 @@ class AddPackageTest extends TestCase
     public function website_url_is_optional()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->from('library')
@@ -197,6 +218,8 @@ class AddPackageTest extends TestCase
     public function donation_url_is_optional()
     {
         $user = factory(User::class)->states('admin')->create();
+        $team = factory(Team::class)->create();
+        $team->users()->attach($user);
 
         $response = $this->actingAs($user)
             ->from('library')

--- a/tests/Feature/Settings/CreateTeamsTest.php
+++ b/tests/Feature/Settings/CreateTeamsTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Feature\Settings;
+
+use App\Team;
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class CreateTeamsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test **/
+    public function create_a_team()
+    {
+        $this->actingAs(new User);
+
+        $response = $this->postJson('/settings/teams', [
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertCount(1, Team::all());
+        $this->assertDatabaseHas('teams', [
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+        $response->assertJsonStructure([
+            'data' => ['id', 'name', 'slug', 'created_at'],
+        ]);
+        $response->assertJsonFragment([
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+    }
+
+    /** @test **/
+    public function unauthenticated_requests_are_dropped()
+    {
+        $response = $this->postJson('/settings/teams', [
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+
+        $response->assertStatus(401);
+        $this->assertCount(0, Team::all());
+    }
+
+    /** @test **/
+    public function name_is_required()
+    {
+        $this->actingAs(new User);
+
+        $response = $this->postJson('/settings/teams', [
+            'name' => '',
+            'slug' => 'my-team',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertCount(0, Team::all());
+    }
+
+    /** @test **/
+    public function slug_is_required()
+    {
+        $this->actingAs(new User);
+
+        $response = $this->postJson('/settings/teams', [
+            'name' => 'My Team',
+            'slug' => '',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertCount(0, Team::all());
+    }
+
+    /** @test **/
+    public function slug_is_unique()
+    {
+        factory(Team::class)->create(['slug' => 'existing-slug']);
+        $this->actingAs(new User);
+
+        $response = $this->postJson('/settings/teams', [
+            'name' => 'My Team',
+            'slug' => 'existing-slug',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertCount(1, Team::all());
+    }
+}

--- a/tests/Feature/Settings/DeleteTeamsTest.php
+++ b/tests/Feature/Settings/DeleteTeamsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Feature\Settings;
+
+use App\Team;
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class DeleteTeamsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test **/
+    public function delete_a_team()
+    {
+        $team = factory(Team::class)->create();
+
+        $this->actingAs(new User);
+        $this->assertCount(1, Team::all());
+
+        $response = $this->deleteJson("/settings/teams/{$team->id}");
+
+        $response->assertStatus(204);
+        $this->assertCount(0, Team::all());
+    }
+
+    /** @test **/
+    public function unauthenticated_requests_are_dropped()
+    {
+        $team = factory(Team::class)->create();
+
+        $this->assertCount(1, Team::all());
+
+        $response = $this->deleteJson("/settings/teams/{$team->id}");
+
+        $response->assertStatus(401);
+        $this->assertCount(1, Team::all());
+    }
+
+    /** @test **/
+    public function invalid_requests_are_dropped()
+    {
+        factory(Team::class)->create();
+
+        $this->actingAs(new User);
+        $this->assertCount(1, Team::all());
+
+        $response = $this->deleteJson('/settings/teams/tokens/99');
+
+        $response->assertStatus(404);
+        $this->assertCount(1, Team::all());
+    }
+}

--- a/tests/Feature/Settings/ListTeamsTest.php
+++ b/tests/Feature/Settings/ListTeamsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Feature\Settings;
+
+use App\Team;
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ListTeamsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test **/
+    public function list_teams()
+    {
+        factory(Team::class)->create(['name' => 'Team A']);
+        factory(Team::class)->create(['name' => 'Team B']);
+        factory(Team::class)->create(['name' => 'Team C']);
+
+        $this->actingAs(new User);
+
+        $response = $this->getJson('/settings/teams');
+
+        $response->assertStatus(200);
+        $response->assertJsonStructure([
+            'data' => [
+                ['id', 'name', 'slug', 'created_at'],
+                ['id', 'name', 'slug', 'created_at'],
+                ['id', 'name', 'slug', 'created_at'],
+            ],
+        ]);
+        $response->assertJsonFragment(['name' => 'Team A']);
+        $response->assertJsonFragment(['name' => 'Team B']);
+        $response->assertJsonFragment(['name' => 'Team C']);
+    }
+
+    /** @test **/
+    public function unauthenticated_requests_are_dropped()
+    {
+        factory(Team::class, 3)->create();
+
+        $response = $this->getJson('/settings/teams');
+
+        $response->assertStatus(401);
+    }
+}

--- a/tests/Feature/Settings/UpdateTeamNameTest.php
+++ b/tests/Feature/Settings/UpdateTeamNameTest.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Feature\Settings;
+
+use App\Team;
+use App\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class UpdateTeamNameTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test **/
+    public function update_a_team_name()
+    {
+        $user = factory(User::class)->create();
+        $team = factory(Team::class)->create([
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+        $team->users()->attach($user);
+
+        $this->actingAs($user);
+
+        $response = $this->patchJson("/settings/teams/{$team->id}/name", [
+            'name' => 'Changed Team',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertCount(1, Team::all());
+        $this->assertDatabaseHas('teams', [
+            'name' => 'Changed Team',
+            'slug' => 'my-team',
+        ]);
+        $response->assertJsonStructure([
+            'data' => ['id', 'name', 'slug', 'created_at'],
+        ]);
+        $response->assertJsonFragment([
+            'name' => 'Changed Team',
+            'slug' => 'my-team',
+        ]);
+    }
+
+    /** @test **/
+    public function drop_unauthenticated_requests()
+    {
+        $user = factory(User::class)->create();
+        $team = factory(Team::class)->create([
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+        $team->users()->attach($user);
+
+        $response = $this->patchJson("/settings/teams/{$team->id}/name", [
+            'name' => 'Changed Team',
+        ]);
+
+        $response->assertStatus(401);
+        $this->assertDatabaseHas('teams', [
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+    }
+
+    /** @test **/
+    public function cannot_update_a_team_that_doesnt_exist()
+    {
+        $user = factory(User::class)->create();
+        $team = factory(Team::class)->create([
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+        $team->users()->attach($user);
+
+        $this->actingAs($user);
+
+        $response = $this->patchJson('/settings/teams/99/name', [
+            'name' => 'Changed Team',
+        ]);
+
+        $response->assertStatus(404);
+        $this->assertDatabaseHas('teams', [
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+    }
+
+    /** @test **/
+    public function name_is_required()
+    {
+        $user = factory(User::class)->create();
+        $team = factory(Team::class)->create([
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+        $team->users()->attach($user);
+
+        $this->actingAs($user);
+
+        $response = $this->patchJson("/settings/teams/{$team->id}/name", [
+            'name' => '',
+        ]);
+
+        $response->assertStatus(422);
+        $this->assertDatabaseHas('teams', [
+            'name' => 'My Team',
+            'slug' => 'my-team',
+        ]);
+    }
+}

--- a/tests/Unit/TeamsTest.php
+++ b/tests/Unit/TeamsTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of Solder.
+ *
+ * (c) Kyle Klaus <kklaus@indemnity83.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Tests\Unit;
+
+use App\Team;
+use App\User;
+use App\Modpack;
+use App\Package;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class TeamsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /** @test **/
+    public function a_team_has_users()
+    {
+        $team = factory(Team::class)->create();
+        $userA = factory(User::class)->create();
+        $userB = factory(User::class)->create();
+        $team->users()->attach($userA);
+
+        $users = $team->users;
+
+        $users->assertContains($userA);
+        $users->assertNotContains($userB);
+    }
+
+    /** @test **/
+    public function a_team_has_many_modpacks()
+    {
+        $team = factory(Team::class)->create();
+        $modpackA = factory(Modpack::class)->create(['team_id' => $team->id]);
+        $modpackB = factory(Modpack::class)->create();
+
+        $modpacks = $team->modpacks;
+
+        $modpacks->assertContains($modpackA);
+        $modpacks->assertNotContains($modpackB);
+    }
+
+    /** @test **/
+    public function a_team_has_many_packages()
+    {
+        $team = factory(Team::class)->create();
+        $packageA = factory(Package::class)->create(['team_id' => $team->id]);
+        $packageB = factory(Package::class)->create();
+
+        $packages = $team->packages;
+
+        $packages->assertContains($packageA);
+        $packages->assertNotContains($packageB);
+    }
+}

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -12,6 +12,7 @@
 namespace Tests\Unit;
 
 use App\Role;
+use App\Team;
 use App\User;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -30,5 +31,29 @@ class UserTest extends TestCase
         $user->grantRole($role->tag);
 
         $this->assertTrue($user->fresh()->roles->contains($role));
+    }
+
+    /** @test **/
+    public function a_user_has_a_current_team()
+    {
+        $team = factory(Team::class)->create();
+        $user = factory(User::class)->create();
+        $user->teams()->attach($team);
+
+        $user->switchToTeam($team);
+
+        $this->assertTrue($user->currentTeam->is($team));
+    }
+
+    /** @test **/
+    public function users_current_team_defaults_to_first_team()
+    {
+        $teamA = factory(Team::class)->create();
+        $teamB = factory(Team::class)->create();
+        $user = factory(User::class)->create(['current_team_id' => null]);
+        $user->teams()->attach($teamA);
+        $user->teams()->attach($teamB);
+
+        $this->assertTrue($user->currentTeam->is($teamA));
     }
 }


### PR DESCRIPTION
Add support for teams in Solder.

This PR only adds the teams themselves, and links Modpacks and Packages to a specific team. This does not handle any permissions or roles that might be in the future be associated with teams. 

Still need to wrap up some things before its ready for merge

 - [x] Add endpoint to update team name
 - [x] Create Vue components for managing Teams